### PR TITLE
add exclude list of issue to ignore deprecate error of GetOkExists

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,10 @@ linters-settings:
   errcheck:
     ignore: github.com/hashicorp/terraform-plugin-sdk/helper/schema:ForceNew|Set
 
+issues:
+    exclude:
+      - GetOkExists
+
 linters:
   enable:
     - deadcode


### PR DESCRIPTION
I created this PR https://github.com/mackerelio-labs/terraform-provider-mackerel/pull/44 .
Although this pull request uses GetOkExists to fix bug, GetOkExists is deprecated now.
So, I updated .golangci.yml to ignore warning of deprecated Error.