### PR TITLE
set Sensitive to api_key

### DIFF
--- a/mackerel/provider.go
+++ b/mackerel/provider.go
@@ -14,6 +14,7 @@ func Provider() terraform.ResourceProvider {
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("MACKEREL_API_KEY", nil),
 				Description: "Mackerel API Key",
+				Sensitive:   true,
 			},
 		},
 


### PR DESCRIPTION
Since Terraform 0.14, make it easier to redact sensitive information in Terraform workflows. and we can define as sensitive at provider schema.

i think api_key is always secret data. so, I want the provider side to treat it as sensitive.