### PR TITLE
changing the "metric" parameter requires destroy and create

### DIFF
--- a/mackerel/resource_mackerel_monitor.go
+++ b/mackerel/resource_mackerel_monitor.go
@@ -47,6 +47,7 @@ func resourceMackerelMonitor() *schema.Resource {
 						"metric": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 						"operator": {
 							Type:         schema.TypeString,
@@ -121,6 +122,7 @@ func resourceMackerelMonitor() *schema.Resource {
 						"metric": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 						"operator": {
 							Type:         schema.TypeString,

--- a/mackerel/resource_mackerel_monitor_test.go
+++ b/mackerel/resource_mackerel_monitor_test.go
@@ -32,7 +32,7 @@ func TestAccMackerelMonitor_HostMetric(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "notification_interval", "0"),
 					resource.TestCheckResourceAttr(resourceName, "host_metric.#", "1"),
 					resource.ComposeTestCheckFunc(
-						resource.TestCheckResourceAttr(resourceName, "host_metric.0.metric", "disk%"),
+						resource.TestCheckResourceAttr(resourceName, "host_metric.0.metric", "cpu.sys"),
 						resource.TestCheckResourceAttr(resourceName, "host_metric.0.operator", ">"),
 						resource.TestCheckResourceAttr(resourceName, "host_metric.0.warning", "75"),
 						resource.TestCheckResourceAttr(resourceName, "host_metric.0.critical", "0"),
@@ -59,7 +59,7 @@ func TestAccMackerelMonitor_HostMetric(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "notification_interval", "30"),
 					resource.TestCheckResourceAttr(resourceName, "host_metric.#", "1"),
 					resource.ComposeTestCheckFunc(
-						resource.TestCheckResourceAttr(resourceName, "host_metric.0.metric", "disk%"),
+						resource.TestCheckResourceAttr(resourceName, "host_metric.0.metric", "cpu.usr"),
 						resource.TestCheckResourceAttr(resourceName, "host_metric.0.operator", ">"),
 						resource.TestCheckResourceAttr(resourceName, "host_metric.0.warning", "70"),
 						resource.TestCheckResourceAttr(resourceName, "host_metric.0.critical", "90"),
@@ -202,7 +202,7 @@ func TestAccMackerelMonitor_ServiceMetric(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "service_metric.#", "1"),
 					resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr(resourceName, "service_metric.0.service", serviceName),
-						resource.TestCheckResourceAttr(resourceName, "service_metric.0.metric", "custom.access.2xx_ratio"),
+						resource.TestCheckResourceAttr(resourceName, "service_metric.0.metric", "custom.access.5xx_ratio"),
 						resource.TestCheckResourceAttr(resourceName, "service_metric.0.operator", "<"),
 						resource.TestCheckResourceAttr(resourceName, "service_metric.0.warning", "99.9"),
 						resource.TestCheckResourceAttr(resourceName, "service_metric.0.critical", "99.99"),
@@ -488,7 +488,7 @@ func testAccMackerelMonitorConfigHostMetric(name string) string {
 resource "mackerel_monitor" "foo" {
   name = "%s"
   host_metric {
-    metric = "disk%%"
+    metric = "cpu.sys"
     operator = ">"
     warning = 75
     duration = 1
@@ -523,7 +523,7 @@ resource "mackerel_monitor" "foo" {
   is_mute = true
   notification_interval = 30
   host_metric {
-    metric = "disk%%"
+    metric = "cpu.usr"
     operator = ">"
     warning = 70
     critical = 90
@@ -619,7 +619,7 @@ resource "mackerel_monitor" "foo" {
   service_metric {
     service = mackerel_service.foo.name
     duration = 3
-    metric = "custom.access.2xx_ratio"
+    metric = "custom.access.5xx_ratio"
     operator = "<"
     warning = 99.9
     critical = 99.99


### PR DESCRIPTION
To change the "metric" parameter in host and service metric monitor, destroy and create are required, so I added "ForceNew".
Also, I changed the test so that TestAcc will fail if there is no "ForceNew."


<details>
<summary>test acc (not "ForceNew")</summary>

```
=== CONT  TestAccMackerelMonitor_ServiceMetric
    testing.go:705: Step 1 error: errors during apply:

        Error: API request failed: cannot change target.

          on /tmp/tf-test228754959/main.tf line 6:
          (source code not available)


--- PASS: TestAccMackerelDowntime_ResourceNotFound (0.57s)
=== CONT  TestAccMackerelChannel_Email
--- PASS: TestAccDataSourceMackerelMonitorExternal (1.40s)
=== CONT  TestAccMackerelChannel_ResourceNotFound
--- FAIL: TestAccMackerelMonitor_ServiceMetric (1.44s)
=== CONT  TestAccMackerelAlertGroupSetting
=== CONT  TestAccMackerelMonitor_HostMetric
    testing.go:705: Step 1 error: errors during apply:

        Error: API request failed: cannot change target.

          on /tmp/tf-test056809309/main.tf line 20:
          (source code not available)
```

</details>

<details>
<summary>test acc ("ForceNew")</summary>

```
?       github.com/mackerelio-labs/terraform-provider-mackerel  [no test files]
=== RUN   TestConfigEmptyAPIKey
--- PASS: TestConfigEmptyAPIKey (0.00s)
=== RUN   TestAccDataSourceMackerelAlertGroupSetting
=== PAUSE TestAccDataSourceMackerelAlertGroupSetting
=== RUN   TestAccDataSourceMackerelChannelEmail
=== PAUSE TestAccDataSourceMackerelChannelEmail
=== RUN   TestAccDataSourceMackerelChannelSlack
=== PAUSE TestAccDataSourceMackerelChannelSlack
=== RUN   TestAccDataSourceMackerelChannelWebhook
=== PAUSE TestAccDataSourceMackerelChannelWebhook
=== RUN   TestAccDataSourceMackerelChannelNotMatchAnyChannel
=== PAUSE TestAccDataSourceMackerelChannelNotMatchAnyChannel
=== RUN   TestAccDataSourceMackerelDowntime
=== PAUSE TestAccDataSourceMackerelDowntime
=== RUN   TestAccDataSourceMackerelDowntimeNotMatchAnyDowntime
=== PAUSE TestAccDataSourceMackerelDowntimeNotMatchAnyDowntime
=== RUN   TestAccDataSourceMackerelMonitorHostMetric
=== PAUSE TestAccDataSourceMackerelMonitorHostMetric
=== RUN   TestAccDataSourceMackerelMonitorConnectivity
=== PAUSE TestAccDataSourceMackerelMonitorConnectivity
=== RUN   TestAccDataSourceMackerelMonitorServiceMetric
=== PAUSE TestAccDataSourceMackerelMonitorServiceMetric
=== RUN   TestAccDataSourceMackerelMonitorExternal
=== PAUSE TestAccDataSourceMackerelMonitorExternal
=== RUN   TestAccDataSourceMackerelMonitorExpression
=== PAUSE TestAccDataSourceMackerelMonitorExpression
=== RUN   TestAccDataSourceMackerelMonitorAnomalyDetection
=== PAUSE TestAccDataSourceMackerelMonitorAnomalyDetection
=== RUN   TestAccDataSourceMackerelNotificationGroup
=== PAUSE TestAccDataSourceMackerelNotificationGroup
=== RUN   TestDataSourceMackerelRoleMetadata
=== PAUSE TestDataSourceMackerelRoleMetadata
=== RUN   TestAccDataSourceMackerelRole
=== PAUSE TestAccDataSourceMackerelRole
=== RUN   TestAccDataSourceMackerelServiceMetadata
=== PAUSE TestAccDataSourceMackerelServiceMetadata
=== RUN   TestAccDataSourceMackerelServiceMetadata_NoMatchReturnsError
=== PAUSE TestAccDataSourceMackerelServiceMetadata_NoMatchReturnsError
=== RUN   TestAccDataSourceMackerelService
=== PAUSE TestAccDataSourceMackerelService
=== RUN   TestAccDataSourceMackerelServiceNotMatchAnyService
=== PAUSE TestAccDataSourceMackerelServiceNotMatchAnyService
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProviderImpl
--- PASS: TestProviderImpl (0.00s)
=== RUN   TestAccMackerelAlertGroupSetting
=== PAUSE TestAccMackerelAlertGroupSetting
=== RUN   TestAccMackerelChannel_Email
=== PAUSE TestAccMackerelChannel_Email
=== RUN   TestAccMackerelChannel_Slack
--- PASS: TestAccMackerelChannel_Slack (1.26s)
=== RUN   TestAccMackerelChannel_Webhook
--- PASS: TestAccMackerelChannel_Webhook (1.05s)
=== RUN   TestAccMackerelChannel_ResourceNotFound
=== PAUSE TestAccMackerelChannel_ResourceNotFound
=== RUN   TestAccMackerelDowntime
=== PAUSE TestAccMackerelDowntime
=== RUN   TestAccMackerelDowntime_ResourceNotFound
=== PAUSE TestAccMackerelDowntime_ResourceNotFound
=== RUN   TestAccMackerelMonitor_HostMetric
=== PAUSE TestAccMackerelMonitor_HostMetric
=== RUN   TestAccMackerelMonitor_Connectivity
--- PASS: TestAccMackerelMonitor_Connectivity (1.99s)
=== RUN   TestAccMackerelMonitor_ServiceMetric
=== PAUSE TestAccMackerelMonitor_ServiceMetric
=== RUN   TestAccMackerelMonitor_External
--- PASS: TestAccMackerelMonitor_External (1.52s)
=== RUN   TestAccMackerelMonitor_Expression
--- PASS: TestAccMackerelMonitor_Expression (1.35s)
=== RUN   TestAccMackerelMonitor_AnomalyDetection
=== PAUSE TestAccMackerelMonitor_AnomalyDetection
=== RUN   TestAccMackerelNotificationGroup
=== PAUSE TestAccMackerelNotificationGroup
=== RUN   TestAccMackerelNotificationGroup_ResourceNotFound
=== PAUSE TestAccMackerelNotificationGroup_ResourceNotFound
=== RUN   TestAccMackerelRoleMetadata
=== PAUSE TestAccMackerelRoleMetadata
=== RUN   TestAccMackerelRole
=== PAUSE TestAccMackerelRole
=== RUN   TestAccMackerelServiceMetadata
=== PAUSE TestAccMackerelServiceMetadata
=== RUN   TestAccMackerelService
=== PAUSE TestAccMackerelService
=== RUN   TestAccMackerelService_ResourceNotFound
=== PAUSE TestAccMackerelService_ResourceNotFound
=== CONT  TestAccDataSourceMackerelAlertGroupSetting
=== CONT  TestAccDataSourceMackerelService
=== CONT  TestAccMackerelDowntime
=== CONT  TestAccMackerelMonitor_AnomalyDetection
=== CONT  TestAccMackerelChannel_Email
=== CONT  TestAccMackerelMonitor_HostMetric
=== CONT  TestAccMackerelDowntime_ResourceNotFound
=== CONT  TestAccMackerelChannel_ResourceNotFound
--- PASS: TestAccMackerelDowntime_ResourceNotFound (0.53s)
=== CONT  TestAccMackerelServiceMetadata
--- PASS: TestAccMackerelChannel_ResourceNotFound (0.57s)
=== CONT  TestAccMackerelService_ResourceNotFound
--- PASS: TestAccDataSourceMackerelService (0.64s)
=== CONT  TestAccMackerelService
--- PASS: TestAccMackerelService_ResourceNotFound (0.34s)
=== CONT  TestAccMackerelMonitor_ServiceMetric
--- PASS: TestAccMackerelChannel_Email (1.14s)
=== CONT  TestAccMackerelRoleMetadata
--- PASS: TestAccDataSourceMackerelAlertGroupSetting (1.37s)
=== CONT  TestAccMackerelRole
--- PASS: TestAccMackerelService (0.89s)
=== CONT  TestAccMackerelAlertGroupSetting
--- PASS: TestAccMackerelServiceMetadata (1.26s)
=== CONT  TestAccDataSourceMackerelMonitorServiceMetric
--- PASS: TestAccMackerelDowntime (1.87s)
=== CONT  TestAccDataSourceMackerelServiceMetadata_NoMatchReturnsError
--- PASS: TestAccDataSourceMackerelServiceMetadata_NoMatchReturnsError (0.07s)
=== CONT  TestAccDataSourceMackerelServiceMetadata
--- PASS: TestAccMackerelMonitor_HostMetric (1.95s)
=== CONT  TestAccDataSourceMackerelRole
--- PASS: TestAccMackerelMonitor_AnomalyDetection (2.15s)
=== CONT  TestDataSourceMackerelRoleMetadata
--- PASS: TestAccMackerelRole (1.38s)
=== CONT  TestAccDataSourceMackerelNotificationGroup
--- PASS: TestAccDataSourceMackerelServiceMetadata (0.89s)
=== CONT  TestAccDataSourceMackerelMonitorAnomalyDetection
--- PASS: TestAccMackerelMonitor_ServiceMetric (1.96s)
=== CONT  TestAccDataSourceMackerelMonitorExpression
--- PASS: TestAccDataSourceMackerelRole (0.92s)
=== CONT  TestAccDataSourceMackerelMonitorExternal
--- PASS: TestAccMackerelRoleMetadata (1.73s)
=== CONT  TestAccMackerelNotificationGroup_ResourceNotFound
--- PASS: TestAccDataSourceMackerelMonitorServiceMetric (1.13s)
=== CONT  TestAccMackerelNotificationGroup
--- PASS: TestAccMackerelAlertGroupSetting (1.70s)
=== CONT  TestAccDataSourceMackerelDowntime
--- PASS: TestDataSourceMackerelRoleMetadata (1.17s)
=== CONT  TestAccDataSourceMackerelMonitorConnectivity
--- PASS: TestAccMackerelNotificationGroup_ResourceNotFound (0.63s)
=== CONT  TestAccDataSourceMackerelMonitorHostMetric
--- PASS: TestAccDataSourceMackerelMonitorExpression (0.83s)
=== CONT  TestAccDataSourceMackerelDowntimeNotMatchAnyDowntime
--- PASS: TestAccDataSourceMackerelDowntimeNotMatchAnyDowntime (0.09s)
=== CONT  TestAccDataSourceMackerelChannelWebhook
--- PASS: TestAccDataSourceMackerelNotificationGroup (1.12s)
=== CONT  TestAccDataSourceMackerelChannelNotMatchAnyChannel
--- PASS: TestAccDataSourceMackerelChannelNotMatchAnyChannel (0.09s)
=== CONT  TestAccDataSourceMackerelChannelSlack
--- PASS: TestAccDataSourceMackerelMonitorExternal (1.10s)
=== CONT  TestAccDataSourceMackerelServiceNotMatchAnyService
--- PASS: TestAccDataSourceMackerelServiceNotMatchAnyService (0.09s)
=== CONT  TestAccDataSourceMackerelChannelEmail
--- PASS: TestAccDataSourceMackerelMonitorAnomalyDetection (1.34s)
--- PASS: TestAccDataSourceMackerelChannelWebhook (0.64s)
--- PASS: TestAccDataSourceMackerelDowntime (1.33s)
--- PASS: TestAccDataSourceMackerelChannelEmail (0.60s)
--- PASS: TestAccDataSourceMackerelChannelSlack (0.71s)
--- PASS: TestAccDataSourceMackerelMonitorConnectivity (1.40s)
--- PASS: TestAccMackerelNotificationGroup (1.85s)
--- PASS: TestAccDataSourceMackerelMonitorHostMetric (1.41s)
PASS
coverage: 94.0% of statements
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel 12.125s coverage: 94.0% of statements
```

</details>
