### PR TITLE
fix documentation about resource mackerel_service

### DIFF
--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -18,7 +18,7 @@ resource "mackerel_service" "foo" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of role.
+* `name` - (Required) The name of service.
 * `memo` - Notes related to this service.
 
 ## Attributes Reference


### PR DESCRIPTION
I think `name` is the name of service, not the role. I propose changes. Please review it.