### PR TITLE
add follow_redirect option on external monitoring

### DIFF
--- a/docs/data-sources/monitor.md
+++ b/docs/data-sources/monitor.md
@@ -62,6 +62,7 @@ data "mackerel_monitor" "this" {
   * `skip_certificate_verification` - Whether verify the certificate when monitoring a server with a self-signed certificate or not.
   * `headers` - The values configured as the HTTP request header.
   * `max_check_attempts` - Number of consecutive Warning/Critical counts before an alert is made.
+  * `follow_redirect` - Evaluates the response of the redirector as a result.
 * `expression` -  The settings for the monitor of expression monitoring.
   * `expression` - Expression of the monitoring target.
   * `operator` - The comparison operator to determines the conditions that state whether the designated variable is either big or small. The observed value is on the left of the operator and the designated value is on the right.

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -161,6 +161,7 @@ The following arguments are required:
 * `skip_certificate_verification` - Whether verify the certificate when monitoring a server with a self-signed certificate or not. Valid values are `true` and `false`.
 * `headers` - The values configured as the HTTP request header.
 * `max_check_attempts` - Number of consecutive Warning/Critical counts before an alert is made. Default is `1`.
+* `follow_redirect` - Evaluates the response of the redirector as a result. Valid values are `true` and `false`.
 
 ### expression
 

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.15
 require (
 	github.com/golangci/golangci-lint v1.36.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
-	github.com/mackerelio/mackerel-client-go v0.14.0
+	github.com/mackerelio/mackerel-client-go v0.19.0
 )

--- a/go.sum
+++ b/go.sum
@@ -409,8 +409,8 @@ github.com/kyoh86/exportloopref v0.1.8/go.mod h1:1tUcJeiioIs7VWe5gcOObrux3lb66+s
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.9.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
-github.com/mackerelio/mackerel-client-go v0.14.0 h1:RUXRMLbRsQbhTSIj6hmuBOkirG8kBQmqK/6dLVmV5UM=
-github.com/mackerelio/mackerel-client-go v0.14.0/go.mod h1:/GNOj+y1eFsd3CK8c6IQ/uS38/GT0+NWImk5YGJs5Lk=
+github.com/mackerelio/mackerel-client-go v0.19.0 h1:DkYVD07fmklFTMKLaHcjtkU53Nt+nhvXNUSEeKfRSZs=
+github.com/mackerelio/mackerel-client-go v0.19.0/go.mod h1:/GNOj+y1eFsd3CK8c6IQ/uS38/GT0+NWImk5YGJs5Lk=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/maratori/testpackage v1.0.1 h1:QtJ5ZjqapShm0w5DosRjg0PRlSdAdlx+W6cCKoALdbQ=

--- a/mackerel/data_source_mackerel_monitor.go
+++ b/mackerel/data_source_mackerel_monitor.go
@@ -197,6 +197,10 @@ func dataSourceMackerelMonitor() *schema.Resource {
 							Sensitive: true,
 							Elem:      &schema.Schema{Type: schema.TypeString},
 						},
+						"follow_redirect": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/mackerel/data_source_mackerel_monitor_test.go
+++ b/mackerel/data_source_mackerel_monitor_test.go
@@ -158,6 +158,7 @@ func TestAccDataSourceMackerelMonitorExternal(t *testing.T) {
 						resource.TestCheckResourceAttr(dsName, "external.0.skip_certificate_verification", "true"),
 						resource.TestCheckResourceAttr(dsName, "external.0.headers.%", "1"),
 						resource.TestCheckResourceAttr(dsName, "external.0.headers.Cache-Control", "no-cache"),
+						resource.TestCheckResourceAttr(dsName, "external.0.follow_redirect", "true"),
 					),
 					resource.TestCheckResourceAttr(dsName, "expression.#", "0"),
 					resource.TestCheckResourceAttr(dsName, "anomaly_detection.#", "0"),
@@ -383,6 +384,7 @@ resource "mackerel_monitor" "foo" {
     headers = {
       Cache-Control = "no-cache"
     }
+    follow_redirect = true
   }
 }
 

--- a/mackerel/resource_mackerel_monitor.go
+++ b/mackerel/resource_mackerel_monitor.go
@@ -463,6 +463,7 @@ func expandMonitorExternalHTTP(d *schema.ResourceData) *mackerel.MonitorExternal
 		CertificationExpirationWarning:  nil,
 		SkipCertificateVerification:     d.Get("external.0.skip_certificate_verification").(bool),
 		Headers:                         []mackerel.HeaderField{},
+		FollowRedirect:                  d.Get("external.0.follow_redirect").(bool),
 	}
 	if responseTimeCritical, ok := d.GetOkExists("external.0.response_time_critical"); ok {
 		responseTimeCritical := responseTimeCritical.(float64)

--- a/mackerel/resource_mackerel_monitor_test.go
+++ b/mackerel/resource_mackerel_monitor_test.go
@@ -265,6 +265,7 @@ func TestAccMackerelMonitor_External(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "external.0.certification_expiration_warning", "0"),
 						resource.TestCheckResourceAttr(resourceName, "external.0.skip_certificate_verification", "false"),
 						resource.TestCheckResourceAttr(resourceName, "external.0.headers.%", "0"),
+						resource.TestCheckResourceAttr(resourceName, "external.0.follow_redirect", "false"),
 					),
 					resource.TestCheckResourceAttr(resourceName, "expression.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "anomaly_detection.#", "0"),
@@ -298,6 +299,7 @@ func TestAccMackerelMonitor_External(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "external.0.skip_certificate_verification", "true"),
 						resource.TestCheckResourceAttr(resourceName, "external.0.headers.%", "1"),
 						resource.TestCheckResourceAttr(resourceName, "external.0.headers.Cache-Control", "no-cache"),
+						resource.TestCheckResourceAttr(resourceName, "external.0.follow_redirect", "true"),
 					),
 					resource.TestCheckResourceAttr(resourceName, "expression.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "anomaly_detection.#", "0"),
@@ -670,6 +672,7 @@ resource "mackerel_monitor" "foo" {
     headers = {
       Cache-Control = "no-cache"
     }
+    follow_redirect = true
   }
 }
 `, serviceName, name)

--- a/mackerel/structure_flattens.go
+++ b/mackerel/structure_flattens.go
@@ -155,6 +155,7 @@ func flattenMonitorExternalHTTP(monitor *mackerel.MonitorExternalHTTP, d *schema
 		"certification_expiration_warning":  monitor.CertificationExpirationWarning,
 		"skip_certificate_verification":     monitor.SkipCertificateVerification,
 		"headers":                           headers,
+		"follow_redirect":                   monitor.FollowRedirect,
 	}
 	d.Set("external", []map[string]interface{}{external})
 	return diags


### PR DESCRIPTION
Add follow_redirect option on external monitoring added in [mackerel-client-go v0.19.0](https://github.com/mackerelio/mackerel-client-go/releases/tag/v0.19.0)

