### PR TITLE
add support for API_BASE that changes the mackerel API endpoint

### DIFF
--- a/mackerel/config.go
+++ b/mackerel/config.go
@@ -9,14 +9,26 @@ import (
 )
 
 type Config struct {
-	APIKey string
+	APIKey  string
+	APIBase string
 }
 
 func (c *Config) Client() (client *mackerel.Client, diags diag.Diagnostics) {
+	var err error
+
 	if c.APIKey == "" {
 		return nil, diag.Errorf("no API Key for Mackerel")
 	}
-	client = mackerel.NewClient(c.APIKey)
+
+	if c.APIBase == "" {
+		client = mackerel.NewClient(c.APIKey)
+	} else {
+		client, err = mackerel.NewClientWithOptions(c.APIKey, c.APIBase, false)
+		if err != nil {
+			return nil, diag.Errorf("failed to create mackerel client: %s", err)
+		}
+	}
+
 	client.HTTPClient.Transport = logging.NewTransport("Mackerel", http.DefaultTransport)
 	return client, diags
 }

--- a/mackerel/provider.go
+++ b/mackerel/provider.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 // Provider returns a *schema.Provider
@@ -17,6 +18,14 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("MACKEREL_API_KEY", nil),
 				Description: "Mackerel API Key",
 				Sensitive:   true,
+			},
+			"api_base": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				DefaultFunc:  schema.EnvDefaultFunc("API_BASE", nil),
+				Description:  "Mackerel API BASE URL",
+				Sensitive:    true,
+				ValidateFunc: validation.IsURLWithHTTPorHTTPS,
 			},
 		},
 
@@ -50,7 +59,8 @@ func Provider() *schema.Provider {
 
 func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	config := Config{
-		APIKey: d.Get("api_key").(string),
+		APIKey:  d.Get("api_key").(string),
+		APIBase: d.Get("api_base").(string),
 	}
 	return config.Client()
 }


### PR DESCRIPTION
API_BASE is used when you want to modify the mackerel API endpoint for debugging or particular environments.