### PR TITLE
add default value to follow_redirect in monitor

### DIFF
--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -148,7 +148,7 @@ The following arguments are required:
 
 ### external
 
-* `method` - (Required) Request method.  Valid values are `GET`, `POST`, `PUT` or `DELETE`.
+* `method` - (Required) Request method. Valid values are `GET`, `POST`, `PUT` or `DELETE`.
 * `url` - (Required) Monitoring target URL.
 * `service` - Service name. When response time is monitored, it will be graphed as the service metrics of this.
 * `response_time_warning` - The response time threshold for warning alerts in milliseconds. Required with `service`.
@@ -161,7 +161,7 @@ The following arguments are required:
 * `skip_certificate_verification` - Whether verify the certificate when monitoring a server with a self-signed certificate or not. Valid values are `true` and `false`.
 * `headers` - The values configured as the HTTP request header.
 * `max_check_attempts` - Number of consecutive Warning/Critical counts before an alert is made. Default is `1`.
-* `follow_redirect` - Evaluates the response of the redirector as a result. Valid values are `true` and `false`.
+* `follow_redirect` - Evaluates the response of the redirector as a result. Valid values are `true` and `false`. Default is `false`.
 
 ### expression
 


### PR DESCRIPTION
`follow_redirect` is enabled when created on website and it's not enabled when created from api. 
see. https://mackerel.io/api-docs/entry/monitors#create

So, I think it's better to describe default value in documentation.