### PR TITLE
add MACKEREL_APIKEY as an alias of MACKEREL_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Mackerel terraform provider offers two ways of setting credential.
 
 ### Environment Variables
 
-You can provide your Mackerel API key using environment variables, `MACKEREL_API_KEY`.
+You can provide your Mackerel API key using environment variables, `MACKEREL_APIKEY` or `MACKEREL_API_KEY`.
 
 ### Static credentials
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ Mackerel terraform provider offers two ways of setting credential.
 
 ### Environment Variables
 
-You can provide your Mackerel API key using environment variables, `MACKEREL_API_KEY`.
+You can provide your Mackerel API key using environment variables, `MACKEREL_APIKEY` or `MACKEREL_API_KEY`.
 
 ### Static credentials
 
@@ -58,5 +58,5 @@ provider "mackerel" {
 
 ## Argument Reference
 
-* `api_key` - (Optional) Mackerel API Key. It must be provided, but it can also be sourced from the `MACKEREL_API_KEY` environment variable.
+* `api_key` - (Optional) Mackerel API Key. It must be provided, but it can also be sourced either from the `MACKEREL_APIKEY` or from the `MACKEREL_API_KEY` environment variable.
 * `api_base` - (Optional) Mackerel API Endpoint. It can also be sourced from the `API_BASE` environment variable.

--- a/mackerel/provider.go
+++ b/mackerel/provider.go
@@ -13,9 +13,12 @@ func Provider() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"api_key": {
-				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("MACKEREL_API_KEY", nil),
+				Type:     schema.TypeString,
+				Required: true,
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"MACKEREL_APIKEY",
+					"MACKEREL_API_KEY",
+				}, nil),
 				Description: "Mackerel API Key",
 				Sensitive:   true,
 			},

--- a/mackerel/provider_test.go
+++ b/mackerel/provider_test.go
@@ -1,10 +1,12 @@
 package mackerel
 
 import (
+	"context"
 	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 var testAccProvider *schema.Provider
@@ -22,6 +24,48 @@ func init() {
 func TestProvider(t *testing.T) {
 	if err := Provider().InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestProvider_apiKeyCompat(t *testing.T) {
+	config := make(map[string]interface{})
+	c := terraform.NewResourceConfigRaw(config)
+	ctx := context.Background()
+	t.Run("MACKEREL_API_KEY", func(t *testing.T) {
+		testSetenv(t, "MACKEREL_API_KEY", "apikey1")
+		testSetenv(t, "MACKEREL_APIKEY", "")
+		if err := Provider().Configure(ctx, c); err != nil {
+			t.Errorf("Configure: %v", err)
+		}
+	})
+	t.Run("MACKEREL_APIKEY", func(t *testing.T) {
+		testSetenv(t, "MACKEREL_API_KEY", "")
+		testSetenv(t, "MACKEREL_APIKEY", "apikey1")
+		if err := Provider().Configure(ctx, c); err != nil {
+			t.Errorf("Configure: %v", err)
+		}
+	})
+}
+
+func testSetenv(t testing.TB, name, val string) {
+	t.Helper()
+
+	setenv := func(name, val string) error {
+		if val == "" {
+			return os.Unsetenv(name)
+		} else {
+			return os.Setenv(name, val)
+		}
+	}
+
+	s := os.Getenv(name)
+	t.Cleanup(func() {
+		if err := setenv(name, s); err != nil {
+			t.Fatalf("Setenv(%q, %q): %v", name, val, err)
+		}
+	})
+	if err := setenv(name, val); err != nil {
+		t.Fatalf("Setenv(%q, %q): %v", name, val, err)
 	}
 }
 


### PR DESCRIPTION
I added *MACKEREL_APIKEY* environment variable.

Mackerel tools, such as *mkr*, uses *MACKEREL_APIKEY* environment variable.