### PR TITLE
add debug-mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,12 +1,35 @@
 package main
 
 import (
+	"context"
+	"flag"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
 	"github.com/mackerelio-labs/terraform-provider-mackerel/mackerel"
 )
 
+const (
+	providerAddr = "registry.terraform.io/mackerelio-labs/mackerel"
+)
+
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: mackerel.Provider})
+	var debug bool
+	flag.BoolVar(&debug, "debug", false, "run as debug-mode")
+
+	flag.Parse()
+
+	opts := &plugin.ServeOpts{
+		ProviderFunc: mackerel.Provider,
+	}
+
+	if debug {
+		if err := plugin.Debug(context.TODO(), providerAddr, opts); err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
+
+	plugin.Serve(opts)
 }

--- a/main.go
+++ b/main.go
@@ -25,7 +25,8 @@ func main() {
 	}
 
 	if debug {
-		if err := plugin.Debug(context.TODO(), providerAddr, opts); err != nil {
+		c := context.TODO() // to support cancellation operations such as signal handling in the future.
+		if err := plugin.Debug(c, providerAddr, opts); err != nil {
 			log.Fatal(err)
 		}
 		return


### PR DESCRIPTION
Added a debug mode to debug the provider using [go\-delve/delve](https://github.com/go-delve/delve), etc.

```console
dlv debug -- -debug
```

Usage:

- Start the provider with the `-debug` flag.
- Copy the output `TF_REATTACH_PROVIDERS`.
- Open a new terminal and export the copied `TF_REATTACH_PROVIDERS`.
- Run terraform.
