### PR TITLE
Update Go version to 1.16 for Apple Silicon (M1) darwin_arm64 Support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       -
         name: Import GPG key
         id: import_gpg

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mackerelio-labs/terraform-provider-mackerel
 
-go 1.15
+go 1.16
 
 require (
 	github.com/golangci/golangci-lint v1.36.0


### PR DESCRIPTION
## Problem
I am using the M1 Macbook Pro, and I cannot get terraform-provider-mackerel working (it works on my Intel Macbook Pro).

### terraform version / terraform init
I installed terraform via homebrew ( `brew install terraform` )

```sh
$ terraform version
Terraform v1.1.0
on darwin_arm64
+ provider registry.terraform.io/mackerelio-labs/mackerel v0.0.7
```

```sh
$ terraform init
Initializing modules...
...
Initializing provider plugins...
- Reusing previous version of mackerelio-labs/mackerel from the dependency lock file
╷
│ Error: Incompatible provider version
│
│ Provider registry.terraform.io/mackerelio-labs/mackerel v0.0.7 does not have a package available for your current platform, darwin_arm64.
│
│ Provider releases are separate from Terraform CLI releases, so not all providers are available for all platforms. Other versions of this provider may have different platforms supported.
```

## What I've done

I've found out that Go version needs to be updated to 1.16 for the build to work on Apple Silicon, so I tried updating.

References:
- https://github.com/hashicorp/terraform-provider-aws/issues/16948
- https://tip.golang.org/doc/go1.16

> Go 1.16 adds support of 64-bit ARM architecture on macOS (also known as Apple Silicon) with GOOS=darwin, GOARCH=arm64. Like the darwin/amd64 port, the darwin/arm64 port supports cgo, internal and external linking, c-archive, c-shared, and pie build modes, and the race detector.

## TODO
I haven't actually tried out whether or not building this locally works