### PR TITLE
Fix: Input 'job-number' has been deprecated with message: use flag-name instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-profile: coverage.txt
           parallel: true
-          job-number: ${{ strategy.job-index }}
+          flag-name: Go-${{ matrix-os }}
 
   finish:
     needs: acceptance-test


### PR DESCRIPTION
Same as https://github.com/mackerelio/mackerel-agent-plugins/pull/871