### PR TITLE
Add support for Route53, Amazon Connect, DocumentDB, CodeBuild to Integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=mackerelio-labs
 NAME=mackerel
 BINARY=terraform-provider-${NAME}
-VERSION=9.9.9
-OS_ARCH=darwin_amd64 # change according to your environment
+VERSION=99.9.9
+OS_ARCH=$(shell go env GOHOSTOS)_$(shell go env GOHOSTARCH)
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,13 @@
 export TF_ACC=1
 
+# Values to install the provider locally for testing purposes
+HOSTNAME=registry.terraform.io
+NAMESPACE=mackerelio-labs
+NAME=mackerel
+BINARY=terraform-provider-${NAME}
+VERSION=9.9.9
+OS_ARCH=darwin_amd64 # change according to your environment
+
 .PHONY: test
 test:
 	go test ./... -v -timeout 120m -coverprofile coverage.txt -covermode atomic
@@ -7,3 +15,12 @@ test:
 .PHONY: testacc
 testacc:
 	TF_ACC=1 go test -v ./mackerel/... -run $(TESTS) -timeout 120m
+
+.PHONY: local-build
+local-build:
+	go build -o ${BINARY}
+
+.PHONY: local-install
+local-install: local-build
+	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
+	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}

--- a/mackerel/resource_mackerel_aws_integration.go
+++ b/mackerel/resource_mackerel_aws_integration.go
@@ -85,6 +85,10 @@ var awsIntegrationServicesKey = map[string]string{
 	"batch":       "Batch",
 	"waf":         "WAF",
 	"billing":     "Billing",
+	"route53":     "Route53",
+	"connect":     "Connect",
+	"docdb":       "DocDB",
+	"codebuild":   "CodeBuild",
 }
 
 func resourceMackerelAWSIntegration() *schema.Resource {


### PR DESCRIPTION
Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.78s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       9.447s
```

other log: https://github.com/mackerelio-labs/terraform-provider-mackerel/pull/106#issue-1364210232