### PR TITLE
aws_integration: set `Sensitive` to `key`

### DIFF
--- a/mackerel/resource_mackerel_aws_integration.go
+++ b/mackerel/resource_mackerel_aws_integration.go
@@ -112,6 +112,7 @@ func resourceMackerelAWSIntegration() *schema.Resource {
 			"key": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Sensitive: true,
 			},
 			"secret_key": {
 				Type:      schema.TypeString,
@@ -121,6 +122,7 @@ func resourceMackerelAWSIntegration() *schema.Resource {
 			"role_arn": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Sensitive: true,
 			},
 			"external_id": {
 				Type:      schema.TypeString,

--- a/mackerel/resource_mackerel_aws_integration.go
+++ b/mackerel/resource_mackerel_aws_integration.go
@@ -120,9 +120,8 @@ func resourceMackerelAWSIntegration() *schema.Resource {
 				Sensitive: true,
 			},
 			"role_arn": {
-				Type:      schema.TypeString,
-				Optional:  true,
-				Sensitive: true,
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"external_id": {
 				Type:      schema.TypeString,

--- a/mackerel/resource_mackerel_aws_integration.go
+++ b/mackerel/resource_mackerel_aws_integration.go
@@ -110,8 +110,8 @@ func resourceMackerelAWSIntegration() *schema.Resource {
 				Optional: true,
 			},
 			"key": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:      schema.TypeString,
+				Optional:  true,
 				Sensitive: true,
 			},
 			"secret_key": {
@@ -120,8 +120,8 @@ func resourceMackerelAWSIntegration() *schema.Resource {
 				Sensitive: true,
 			},
 			"role_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:      schema.TypeString,
+				Optional:  true,
 				Sensitive: true,
 			},
 			"external_id": {


### PR DESCRIPTION
same as: https://github.com/mackerelio-labs/terraform-provider-mackerel/pull/53

Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS=TestAccMackerelAWSIntegration                     
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegration -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== RUN   TestAccMackerelAWSIntegrationCredentials
=== PAUSE TestAccMackerelAWSIntegrationCredentials
=== CONT  TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationCredentials
--- PASS: TestAccMackerelAWSIntegrationCredentials (7.87s)
--- PASS: TestAccMackerelAWSIntegrationIAMRole (7.88s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel8.404s
...
```
