### PR TITLE
fixed panic when range is not set

### DIFF
--- a/mackerel/resource_mackerel_dashboard.go
+++ b/mackerel/resource_mackerel_dashboard.go
@@ -354,12 +354,16 @@ func expandDashboardWidgets(d *schema.ResourceData) []mackerel.Widget {
 		graphs := d.Get("graph").([]interface{})
 		for _, graph := range graphs {
 			g := graph.(map[string]interface{})
+			var r mackerel.Range
+			if v, ok := g["range"].([]interface{}); ok && len(v) > 0 {
+				r = expandDashboardRange(v)
+			}
 			if len(g["host"].([]interface{})) > 0 {
 				widgets = append(widgets, mackerel.Widget{
 					Type:   "graph",
 					Title:  g["title"].(string),
 					Graph:  expandDashboardGraphHost(g["host"].([]interface{})),
-					Range:  expandDashboardRange(g["range"].([]interface{})),
+					Range:  r,
 					Layout: expandDashboardLayout(g["layout"].([]interface{})[0].(map[string]interface{})),
 				})
 			}
@@ -368,7 +372,7 @@ func expandDashboardWidgets(d *schema.ResourceData) []mackerel.Widget {
 					Type:   "graph",
 					Title:  g["title"].(string),
 					Graph:  expandDashboardGraphRole(g["role"].([]interface{})),
-					Range:  expandDashboardRange(g["range"].([]interface{})),
+					Range:  r,
 					Layout: expandDashboardLayout(g["layout"].([]interface{})[0].(map[string]interface{})),
 				})
 			}
@@ -377,7 +381,7 @@ func expandDashboardWidgets(d *schema.ResourceData) []mackerel.Widget {
 					Type:   "graph",
 					Title:  g["title"].(string),
 					Graph:  expandDashboardGraphService(g["service"].([]interface{})),
-					Range:  expandDashboardRange(g["range"].([]interface{})),
+					Range:  r,
 					Layout: expandDashboardLayout(g["layout"].([]interface{})[0].(map[string]interface{})),
 				})
 			}
@@ -386,7 +390,7 @@ func expandDashboardWidgets(d *schema.ResourceData) []mackerel.Widget {
 					Type:   "graph",
 					Title:  g["title"].(string),
 					Graph:  expandDashboardGraphExpression(g["expression"].([]interface{})),
-					Range:  expandDashboardRange(g["range"].([]interface{})),
+					Range:  r,
 					Layout: expandDashboardLayout(g["layout"].([]interface{})[0].(map[string]interface{})),
 				})
 			}


### PR DESCRIPTION
- resolve #137

Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS=TestAccMackerelDashboardGraph
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelDashboardGraph -timeout 120m
=== RUN   TestAccMackerelDashboardGraph
=== PAUSE TestAccMackerelDashboardGraph
=== CONT  TestAccMackerelDashboardGraph
--- PASS: TestAccMackerelDashboardGraph (4.35s)
PASS
ok  	github.com/mackerelio-labs/terraform-provider-mackerel/mackerel	4.932s
```
