### PR TITLE
add MaxItems for list in dashboard schema

### DIFF
--- a/mackerel/resource_mackerel_dashboard.go
+++ b/mackerel/resource_mackerel_dashboard.go
@@ -149,6 +149,7 @@ func resourceMackerelDashboard() *schema.Resource {
 						"host": {
 							Type:     schema.TypeList,
 							Optional: true,
+							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"host_id": {
@@ -165,6 +166,7 @@ func resourceMackerelDashboard() *schema.Resource {
 						"role": {
 							Type:     schema.TypeList,
 							Optional: true,
+							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"role_fullname": {
@@ -186,6 +188,7 @@ func resourceMackerelDashboard() *schema.Resource {
 						"service": {
 							Type:     schema.TypeList,
 							Optional: true,
+							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"service_name": {
@@ -202,6 +205,7 @@ func resourceMackerelDashboard() *schema.Resource {
 						"expression": {
 							Type:     schema.TypeList,
 							Optional: true,
+							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"expression": {
@@ -214,11 +218,13 @@ func resourceMackerelDashboard() *schema.Resource {
 						"range": {
 							Type:     schema.TypeList,
 							Optional: true,
+							MaxItems: 1,
 							Elem:     dashboardRangeResource,
 						},
 						"layout": {
 							Type:     schema.TypeList,
 							Required: true,
+							MaxItems: 1,
 							Elem:     dashboardLayoutResource,
 						},
 					},
@@ -236,6 +242,7 @@ func resourceMackerelDashboard() *schema.Resource {
 						"metric": {
 							Type:     schema.TypeList,
 							Required: true,
+							MaxItems: 1,
 							Elem:     dashboardMetricResource,
 						},
 						"fraction_size": {
@@ -249,6 +256,7 @@ func resourceMackerelDashboard() *schema.Resource {
 						"layout": {
 							Type:     schema.TypeList,
 							Required: true,
+							MaxItems: 1,
 							Elem:     dashboardLayoutResource,
 						},
 					},
@@ -270,6 +278,7 @@ func resourceMackerelDashboard() *schema.Resource {
 						"layout": {
 							Type:     schema.TypeList,
 							Required: true,
+							MaxItems: 1,
 							Elem:     dashboardLayoutResource,
 						},
 					},
@@ -291,6 +300,7 @@ func resourceMackerelDashboard() *schema.Resource {
 						"layout": {
 							Type:     schema.TypeList,
 							Required: true,
+							MaxItems: 1,
 							Elem:     dashboardLayoutResource,
 						},
 					},


### PR DESCRIPTION
The following code is inappropriate but the provider accepts it.

```hcl
  markdown {
    title    = ""
    markdown = "hello, world"
    layout {
      x      = 12
      y      = 7
      width  = 12
      height = 8
    }
    layout {
      x      = 12
      y      = 7
      width  = 12
      height = 8
    }
  }
```

By specifying MaxItem in the list type schema, the above code will not be accepted at `terraform plan`.

```
terraform plan
╷
│ Error: Too many layout blocks
│
│   on main.tf line 148, in resource "mackerel_dashboard" "this":
│  148:       layout {
│
│ No more than 1 "layout" blocks are allowed
╵
```

Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS=TestAccMackerelDashboardGraph
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelDashboardGraph -timeout 120m
=== RUN   TestAccMackerelDashboardGraph
=== PAUSE TestAccMackerelDashboardGraph
=== CONT  TestAccMackerelDashboardGraph
--- PASS: TestAccMackerelDashboardGraph (4.63s)
PASS
ok  	github.com/mackerelio-labs/terraform-provider-mackerel/mackerel	5.259s
```
