### PR TITLE
added retire automatically for RDS

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: golangci/golangci-lint-action@v2
+      - uses: golangci/golangci-lint-action@v3
         with:
           version: latest
+          args: --timeout 5m

--- a/mackerel/data_source_mackerel_aws_integration.go
+++ b/mackerel/data_source_mackerel_aws_integration.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mackerelio/mackerel-client-go"
 )
 
-var awsIntegrationServiceEC2DataResource = &schema.Resource{
+var awsIntegrationServiceDataResourceWithRetireAutomatically = &schema.Resource{
 	Schema: map[string]*schema.Schema{
 		"enable": {
 			Type:     schema.TypeBool,
@@ -30,6 +30,12 @@ var awsIntegrationServiceEC2DataResource = &schema.Resource{
 			Computed: true,
 		},
 	},
+}
+
+var awsIntegrationServiceDataSchemaWithRetireAutomatically = &schema.Schema{
+	Type:     schema.TypeSet,
+	Computed: true,
+	Elem:     awsIntegrationServiceDataResourceWithRetireAutomatically,
 }
 
 var awsIntegrationServiceDataResource = &schema.Resource{
@@ -99,15 +105,12 @@ func dataSourceMackerelAWSIntegration() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"ec2": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     awsIntegrationServiceEC2DataResource,
-			},
 		},
 	}
 	for schemaKey := range awsIntegrationServicesKey {
-		if schemaKey != "ec2" {
+		if schemaKey == "ec2" {
+			resource.Schema[schemaKey] = awsIntegrationServiceDataSchemaWithRetireAutomatically
+		} else if schemaKey != "ec2" {
 			resource.Schema[schemaKey] = awsIntegrationServiceDataSchema
 		}
 	}

--- a/mackerel/data_source_mackerel_aws_integration.go
+++ b/mackerel/data_source_mackerel_aws_integration.go
@@ -107,10 +107,11 @@ func dataSourceMackerelAWSIntegration() *schema.Resource {
 			},
 		},
 	}
+	var supportedRetireAutomatically = map[string]bool{"ec2": true}
 	for schemaKey := range awsIntegrationServicesKey {
-		if schemaKey == "ec2" {
+		if supportedRetireAutomatically[schemaKey] {
 			resource.Schema[schemaKey] = awsIntegrationServiceDataSchemaWithRetireAutomatically
-		} else if schemaKey != "ec2" {
+		} else if !supportedRetireAutomatically[schemaKey] {
 			resource.Schema[schemaKey] = awsIntegrationServiceDataSchema
 		}
 	}

--- a/mackerel/data_source_mackerel_aws_integration.go
+++ b/mackerel/data_source_mackerel_aws_integration.go
@@ -107,7 +107,7 @@ func dataSourceMackerelAWSIntegration() *schema.Resource {
 			},
 		},
 	}
-	var supportedRetireAutomatically = map[string]bool{"ec2": true}
+	var supportedRetireAutomatically = map[string]bool{"ec2": true, "rds": true}
 	for schemaKey := range awsIntegrationServicesKey {
 		if supportedRetireAutomatically[schemaKey] {
 			resource.Schema[schemaKey] = awsIntegrationServiceDataSchemaWithRetireAutomatically

--- a/mackerel/data_source_mackerel_aws_integration_test.go
+++ b/mackerel/data_source_mackerel_aws_integration_test.go
@@ -102,9 +102,10 @@ resource "mackerel_aws_integration" "foo" {
   }
 
   rds {
-    enable           = true
-    role             = "${mackerel_service.include.name}: ${mackerel_role.include.name}"
-    excluded_metrics = ["rds.cpu.used"]
+    enable               = true
+    role                 = "${mackerel_service.include.name}: ${mackerel_role.include.name}"
+    excluded_metrics     = ["rds.cpu.used"]
+    retire_automatically = true
   }
 
   nlb {
@@ -147,9 +148,10 @@ resource "mackerel_aws_integration" "foo" {
   }
 
   rds {
-    enable           = true
-    role             = "${mackerel_service.include.name}: ${mackerel_role.include.name}"
-    excluded_metrics = ["rds.cpu.used"]
+    enable               = true
+    role                 = "${mackerel_service.include.name}: ${mackerel_role.include.name}"
+    excluded_metrics     = ["rds.cpu.used"]
+    retire_automatically = true
   }
 
   nlb {

--- a/mackerel/resource_mackerel_aws_integration.go
+++ b/mackerel/resource_mackerel_aws_integration.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mackerelio/mackerel-client-go"
 )
 
-var awsIntegrationServiceEC2Resource = &schema.Resource{
+var awsIntegrationServiceResourceWithRetireAutomatically = &schema.Resource{
 	Schema: map[string]*schema.Schema{
 		"enable": {
 			Type:     schema.TypeBool,
@@ -31,6 +31,13 @@ var awsIntegrationServiceEC2Resource = &schema.Resource{
 			Optional: true,
 		},
 	},
+}
+
+var awsIntegrationServiceSchemaWithRetireAutomatically = &schema.Schema{
+	Type:     schema.TypeSet,
+	Optional: true,
+	MaxItems: 1,
+	Elem:     awsIntegrationServiceResourceWithRetireAutomatically,
 }
 
 var awsIntegrationServiceResource = &schema.Resource{
@@ -140,16 +147,12 @@ func resourceMackerelAWSIntegration() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"ec2": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				MaxItems: 1,
-				Elem:     awsIntegrationServiceEC2Resource,
-			},
 		},
 	}
 	for schemaKey := range awsIntegrationServicesKey {
-		if schemaKey != "ec2" {
+		if schemaKey == "ec2" {
+			resource.Schema[schemaKey] = awsIntegrationServiceSchemaWithRetireAutomatically
+		} else if schemaKey != "ec2" {
 			resource.Schema[schemaKey] = awsIntegrationServiceSchema
 		}
 	}

--- a/mackerel/resource_mackerel_aws_integration.go
+++ b/mackerel/resource_mackerel_aws_integration.go
@@ -149,10 +149,11 @@ func resourceMackerelAWSIntegration() *schema.Resource {
 			},
 		},
 	}
+	var supportedRetireAutomatically = map[string]bool{"ec2": true}
 	for schemaKey := range awsIntegrationServicesKey {
-		if schemaKey == "ec2" {
+		if supportedRetireAutomatically[schemaKey] {
 			resource.Schema[schemaKey] = awsIntegrationServiceSchemaWithRetireAutomatically
-		} else if schemaKey != "ec2" {
+		} else if !supportedRetireAutomatically[schemaKey] {
 			resource.Schema[schemaKey] = awsIntegrationServiceSchema
 		}
 	}
@@ -230,6 +231,7 @@ func expandUpdateAWSIntegrationParam(d *schema.ResourceData) *mackerel.UpdateAWS
 }
 
 func expandAWSIntegrationServicesSet(d *schema.ResourceData) map[string]*mackerel.AWSIntegrationService {
+	var supportedRetireAutomatically = map[string]bool{"ec2": true}
 	services := make(map[string]*mackerel.AWSIntegrationService)
 	for schemaKey, mapKey := range awsIntegrationServicesKey {
 		if _, ok := d.GetOk(schemaKey); ok {
@@ -240,7 +242,7 @@ func expandAWSIntegrationServicesSet(d *schema.ResourceData) map[string]*mackere
 				Role:            toPointer(service["role"].(string)),
 				ExcludedMetrics: toSliceString(service["excluded_metrics"].([]interface{})),
 			}
-			if schemaKey == "ec2" {
+			if supportedRetireAutomatically[schemaKey] {
 				services[mapKey].RetireAutomatically = service["retire_automatically"].(bool)
 			}
 		}

--- a/mackerel/resource_mackerel_aws_integration.go
+++ b/mackerel/resource_mackerel_aws_integration.go
@@ -149,7 +149,7 @@ func resourceMackerelAWSIntegration() *schema.Resource {
 			},
 		},
 	}
-	var supportedRetireAutomatically = map[string]bool{"ec2": true}
+	var supportedRetireAutomatically = map[string]bool{"ec2": true, "rds": true}
 	for schemaKey := range awsIntegrationServicesKey {
 		if supportedRetireAutomatically[schemaKey] {
 			resource.Schema[schemaKey] = awsIntegrationServiceSchemaWithRetireAutomatically
@@ -231,7 +231,7 @@ func expandUpdateAWSIntegrationParam(d *schema.ResourceData) *mackerel.UpdateAWS
 }
 
 func expandAWSIntegrationServicesSet(d *schema.ResourceData) map[string]*mackerel.AWSIntegrationService {
-	var supportedRetireAutomatically = map[string]bool{"ec2": true}
+	var supportedRetireAutomatically = map[string]bool{"ec2": true, "rds": true}
 	services := make(map[string]*mackerel.AWSIntegrationService)
 	for schemaKey, mapKey := range awsIntegrationServicesKey {
 		if _, ok := d.GetOk(schemaKey); ok {

--- a/mackerel/resource_mackerel_aws_integration_test.go
+++ b/mackerel/resource_mackerel_aws_integration_test.go
@@ -344,9 +344,10 @@ resource "mackerel_aws_integration" "foo" {
   }
 
   rds {
-    enable           = true
-    role             = "${mackerel_service.include.name}: ${mackerel_role.include.name}"
-    excluded_metrics = ["rds.cpu.used"]
+    enable               = true
+    role                 = "${mackerel_service.include.name}: ${mackerel_role.include.name}"
+    excluded_metrics     = ["rds.cpu.used"]
+    retire_automatically = true
   }
 
   nlb {

--- a/mackerel/structure_flattens.go
+++ b/mackerel/structure_flattens.go
@@ -320,6 +320,8 @@ func flattenAWSIntegration(awsIntegration *mackerel.AWSIntegration, d *schema.Re
 	d.Set("included_tags", awsIntegration.IncludedTags)
 	d.Set("excluded_tags", awsIntegration.ExcludedTags)
 
+	var supportedRetireAutomatically = map[string]bool{"EC2": true}
+
 	awsIntegration.Services = deleteAWSIntegrationDisableService(awsIntegration.Services)
 	for key, service := range awsIntegration.Services {
 		s := map[string]interface{}{
@@ -327,7 +329,7 @@ func flattenAWSIntegration(awsIntegration *mackerel.AWSIntegration, d *schema.Re
 			"role":             toString(service.Role),
 			"excluded_metrics": toSliceInterface(service.ExcludedMetrics),
 		}
-		if key == "EC2" {
+		if supportedRetireAutomatically[key] {
 			s["retire_automatically"] = service.RetireAutomatically
 		}
 		d.Set(toAWSIntegrationServicesSchemaKey(key), schema.NewSet(schema.HashResource(awsIntegrationServiceResource), []interface{}{s}))

--- a/mackerel/structure_flattens.go
+++ b/mackerel/structure_flattens.go
@@ -320,7 +320,7 @@ func flattenAWSIntegration(awsIntegration *mackerel.AWSIntegration, d *schema.Re
 	d.Set("included_tags", awsIntegration.IncludedTags)
 	d.Set("excluded_tags", awsIntegration.ExcludedTags)
 
-	var supportedRetireAutomatically = map[string]bool{"EC2": true}
+	var supportedRetireAutomatically = map[string]bool{"EC2": true, "RDS": true}
 
 	awsIntegration.Services = deleteAWSIntegrationDisableService(awsIntegration.Services)
 	for key, service := range awsIntegration.Services {


### PR DESCRIPTION
Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
make testacc TESTS=TestAccDataSourceMackerelAWSIntegrationIAMRole
TF_ACC=1 go test -v ./mackerel/... -run TestAccDataSourceMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccDataSourceMackerelAWSIntegrationIAMRole
=== PAUSE TestAccDataSourceMackerelAWSIntegrationIAMRole
=== CONT  TestAccDataSourceMackerelAWSIntegrationIAMRole
--- PASS: TestAccDataSourceMackerelAWSIntegrationIAMRole (3.57s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel 4.049s
```
