### PR TITLE
Added support for monitors with PromQL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/golangci/golangci-lint v1.50.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
-	github.com/mackerelio/mackerel-client-go v0.26.0
+	github.com/mackerelio/mackerel-client-go v0.31.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -514,6 +514,8 @@ github.com/lufeee/execinquery v1.2.1 h1:hf0Ems4SHcUGBxpGN7Jz78z1ppVkP/837ZlETPCE
 github.com/lufeee/execinquery v1.2.1/go.mod h1:EC7DrEKView09ocscGHC+apXMIaorh4xqSxS/dy8SbM=
 github.com/mackerelio/mackerel-client-go v0.26.0 h1:72hj2zw/rqTUNMNokenRxs6KfJ1aVxRHpZT8X4eOUuA=
 github.com/mackerelio/mackerel-client-go v0.26.0/go.mod h1:b4qVMQi+w4rxtKQIFycLWXNBtIi9d0r571RzYmg/aXo=
+github.com/mackerelio/mackerel-client-go v0.31.0 h1:oUBwuJzZkvhSFf7C7zpOBej8jM0kITUz7eVMAINIfO4=
+github.com/mackerelio/mackerel-client-go v0.31.0/go.mod h1:b4qVMQi+w4rxtKQIFycLWXNBtIi9d0r571RzYmg/aXo=
 github.com/magiconair/properties v1.8.6 h1:5ibWZ6iY0NctNGWo87LalDlEZ6R41TqbbDamhfG/Qzo=
 github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/maratori/testableexamples v1.0.0 h1:dU5alXRrD8WKSjOUnmJZuzdxWOEQ57+7s93SLMxb2vI=

--- a/mackerel/data_source_mackerel_monitor.go
+++ b/mackerel/data_source_mackerel_monitor.go
@@ -257,34 +257,34 @@ func dataSourceMackerelMonitor() *schema.Resource {
 					},
 				},
 			},
-            "query": {
-                Type: schema.TypeList,
-                Computed: true,
-                Elem: &schema.Resource{
-                    Schema: map[string]*schema.Schema{
-                        "query": {
-                            Type: schema.TypeString,
-                            Computed: true,
-                        },
-                        "legend": {
-                            Type: schema.TypeString,
-                            Computed: true,
-                        },
-                        "operator": {
-                            Type: schema.TypeString,
-                            Computed: true,
-                        },
-                        "warning": {
-                            Type: schema.TypeString,
-                            Computed: true,
-                        },
-                        "critical": {
-                            Type: schema.TypeString,
-                            Computed: true,
-                        },
-                    },
-                },
-            },
+			"query": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"query": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"legend": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"operator": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"warning": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"critical": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/mackerel/data_source_mackerel_monitor.go
+++ b/mackerel/data_source_mackerel_monitor.go
@@ -257,6 +257,34 @@ func dataSourceMackerelMonitor() *schema.Resource {
 					},
 				},
 			},
+            "query": {
+                Type: schema.TypeList,
+                Computed: true,
+                Elem: &schema.Resource{
+                    Schema: map[string]*schema.Schema{
+                        "query": {
+                            Type: schema.TypeString,
+                            Computed: true,
+                        },
+                        "legend": {
+                            Type: schema.TypeString,
+                            Computed: true,
+                        },
+                        "operator": {
+                            Type: schema.TypeString,
+                            Computed: true,
+                        },
+                        "warning": {
+                            Type: schema.TypeString,
+                            Computed: true,
+                        },
+                        "critical": {
+                            Type: schema.TypeString,
+                            Computed: true,
+                        },
+                    },
+                },
+            },
 		},
 	}
 }

--- a/mackerel/resource_mackerel_monitor.go
+++ b/mackerel/resource_mackerel_monitor.go
@@ -10,6 +10,18 @@ import (
 	"github.com/mackerelio/mackerel-client-go"
 )
 
+var (
+	monitorTypes = []string{
+		"host_metric",
+		"connectivity",
+		"service_metric",
+		"external",
+		"expression",
+		"anomaly_detection",
+		"query",
+	}
+)
+
 func resourceMackerelMonitor() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceMackerelMonitorCreate,
@@ -42,7 +54,7 @@ func resourceMackerelMonitor() *schema.Resource {
 			"host_metric": {
 				Type:         schema.TypeList,
 				Optional:     true,
-				ExactlyOneOf: []string{"host_metric", "connectivity", "service_metric", "external", "expression", "anomaly_detection"},
+				ExactlyOneOf: monitorTypes,
 				MaxItems:     1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -95,7 +107,7 @@ func resourceMackerelMonitor() *schema.Resource {
 			"connectivity": {
 				Type:         schema.TypeList,
 				Optional:     true,
-				ExactlyOneOf: []string{"host_metric", "connectivity", "service_metric", "external", "expression", "anomaly_detection"},
+				ExactlyOneOf: monitorTypes,
 				MaxItems:     1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -115,7 +127,7 @@ func resourceMackerelMonitor() *schema.Resource {
 			"service_metric": {
 				Type:         schema.TypeList,
 				Optional:     true,
-				ExactlyOneOf: []string{"host_metric", "connectivity", "service_metric", "external", "expression", "anomaly_detection"},
+				ExactlyOneOf: monitorTypes,
 				MaxItems:     1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -177,7 +189,7 @@ func resourceMackerelMonitor() *schema.Resource {
 			"external": {
 				Type:         schema.TypeList,
 				Optional:     true,
-				ExactlyOneOf: []string{"host_metric", "connectivity", "service_metric", "external", "expression", "anomaly_detection"},
+				ExactlyOneOf: monitorTypes,
 				MaxItems:     1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -254,7 +266,7 @@ func resourceMackerelMonitor() *schema.Resource {
 			"expression": {
 				Type:         schema.TypeList,
 				Optional:     true,
-				ExactlyOneOf: []string{"host_metric", "connectivity", "service_metric", "external", "expression", "anomaly_detection"},
+				ExactlyOneOf: monitorTypes,
 				MaxItems:     1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -285,7 +297,7 @@ func resourceMackerelMonitor() *schema.Resource {
 			"anomaly_detection": {
 				Type:         schema.TypeList,
 				Optional:     true,
-				ExactlyOneOf: []string{"host_metric", "connectivity", "service_metric", "external", "expression", "anomaly_detection"},
+				ExactlyOneOf: monitorTypes,
 				MaxItems:     1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -315,6 +327,41 @@ func resourceMackerelMonitor() *schema.Resource {
 							Type:     schema.TypeSet,
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"query": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				ExactlyOneOf: monitorTypes,
+				MaxItems:     1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"query": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"legend": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"operator": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice([]string{">", "<"}, false),
+						},
+						"warning": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							AtLeastOneOf: []string{"query.0.warning", "query.0.critical"},
+							ValidateFunc: ValidateFloatString,
+						},
+						"critical": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							AtLeastOneOf: []string{"query.0.warning", "query.0.critical"},
+							ValidateFunc: ValidateFloatString,
 						},
 					},
 				},
@@ -381,6 +428,9 @@ func expandMonitor(d *schema.ResourceData) mackerel.Monitor {
 	}
 	if _, ok := d.GetOk("anomaly_detection"); ok {
 		monitor = expandMonitorAnomalyDetection(d)
+	}
+	if _, ok := d.GetOk("query"); ok {
+		monitor = expandMonitorQuery(d)
 	}
 	return monitor
 }
@@ -556,6 +606,32 @@ func expandMonitorAnomalyDetection(d *schema.ResourceData) *mackerel.MonitorAnom
 		TrainingPeriodFrom:   uint64(d.Get("anomaly_detection.0.training_period_from").(int)),
 		MaxCheckAttempts:     uint64(d.Get("anomaly_detection.0.max_check_attempts").(int)),
 		Scopes:               expandStringListFromSet(d.Get("anomaly_detection.0.scopes").(*schema.Set)),
+	}
+	return monitor
+}
+
+func expandMonitorQuery(d *schema.ResourceData) *mackerel.MonitorQuery {
+	monitor := &mackerel.MonitorQuery{
+		Name:                 d.Get("name").(string),
+		Memo:                 d.Get("memo").(string),
+		Type:                 "query",
+		IsMute:               d.Get("is_mute").(bool),
+		NotificationInterval: uint64(d.Get("notification_interval").(int)),
+		Query:                d.Get("query.0.query").(string),
+		Legend:               d.Get("query.0.legend").(string),
+		Operator:             d.Get("query.0.operator").(string),
+		Warning:              nil,
+		Critical:             nil,
+	}
+	if warning, ok := d.GetOkExists("query.0.warning"); ok {
+		if w, err := strconv.ParseFloat(warning.(string), 64); err == nil {
+			monitor.Warning = &w
+		}
+	}
+	if critical, ok := d.GetOkExists("query.0.critical"); ok {
+		if c, err := strconv.ParseFloat(critical.(string), 64); err == nil {
+			monitor.Critical = &c
+		}
 	}
 	return monitor
 }

--- a/mackerel/resource_mackerel_monitor.go
+++ b/mackerel/resource_mackerel_monitor.go
@@ -341,6 +341,7 @@ func resourceMackerelMonitor() *schema.Resource {
 						"query": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 						"legend": {
 							Type:     schema.TypeString,

--- a/mackerel/resource_mackerel_monitor_test.go
+++ b/mackerel/resource_mackerel_monitor_test.go
@@ -46,6 +46,7 @@ func TestAccMackerelMonitor_HostMetric(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "external.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "expression.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "anomaly_detection.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "query.#", "0"),
 				),
 			},
 			// Test: Update
@@ -73,6 +74,7 @@ func TestAccMackerelMonitor_HostMetric(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "external.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "expression.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "anomaly_detection.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "query.#", "0"),
 				),
 			},
 			// Test: Import
@@ -115,6 +117,7 @@ func TestAccMackerelMonitor_Connectivity(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "external.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "expression.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "anomaly_detection.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "query.#", "0"),
 				),
 			},
 			// Test: Update
@@ -136,6 +139,7 @@ func TestAccMackerelMonitor_Connectivity(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "external.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "expression.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "anomaly_detection.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "query.#", "0"),
 				),
 			},
 			// Test: Import
@@ -186,6 +190,7 @@ func TestAccMackerelMonitor_ServiceMetric(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "external.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "expression.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "anomaly_detection.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "query.#", "0"),
 				),
 			},
 			// Test: Update
@@ -214,6 +219,7 @@ func TestAccMackerelMonitor_ServiceMetric(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "external.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "expression.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "anomaly_detection.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "query.#", "0"),
 				),
 			},
 			// Test: Import
@@ -269,6 +275,7 @@ func TestAccMackerelMonitor_External(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(resourceName, "expression.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "anomaly_detection.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "query.#", "0"),
 				),
 			},
 			// Test: Update
@@ -303,6 +310,7 @@ func TestAccMackerelMonitor_External(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(resourceName, "expression.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "anomaly_detection.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "query.#", "0"),
 				),
 			},
 			// Test: Import
@@ -346,6 +354,7 @@ func TestAccMackerelMonitor_Expression(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "expression.0.warning", "0.7"),
 					),
 					resource.TestCheckResourceAttr(resourceName, "anomaly_detection.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "query.#", "0"),
 				),
 			},
 			// Test: Update
@@ -369,6 +378,7 @@ func TestAccMackerelMonitor_Expression(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "expression.0.critical", "0.9"),
 					),
 					resource.TestCheckResourceAttr(resourceName, "anomaly_detection.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "query.#", "0"),
 				),
 			},
 			// Test: Import
@@ -414,6 +424,7 @@ func TestAccMackerelMonitor_AnomalyDetection(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "anomaly_detection.0.training_period_from", "0"),
 						resource.TestCheckResourceAttr(resourceName, "anomaly_detection.0.scopes.#", "1"),
 					),
+					resource.TestCheckResourceAttr(resourceName, "query.#", "0"),
 				),
 			},
 			// Test: Update
@@ -437,6 +448,77 @@ func TestAccMackerelMonitor_AnomalyDetection(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "anomaly_detection.0.max_check_attempts", "5"),
 						resource.TestCheckResourceAttr(resourceName, "anomaly_detection.0.training_period_from", "1577836800"),
 						resource.TestCheckResourceAttr(resourceName, "anomaly_detection.0.scopes.#", "1"),
+					),
+					resource.TestCheckResourceAttr(resourceName, "query.#", "0"),
+				),
+			},
+			// Test: Import
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccMackerelMonitor_Query(t *testing.T) {
+	resourceName := "mackerel_monitor.foo"
+	rand := acctest.RandString(5)
+	name := fmt.Sprintf("tf-monitor query %s", rand)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMackerelMonitorDestroy,
+		Steps: []resource.TestStep{
+			// Test: Create
+			{
+				Config: testAccMackerelMonitorConfigQuery(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMackerelMonitorExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "memo", ""),
+					resource.TestCheckResourceAttr(resourceName, "is_mute", "false"),
+					resource.TestCheckResourceAttr(resourceName, "notification_interval", "0"),
+					resource.TestCheckResourceAttr(resourceName, "host_metric.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "connectivity.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "service_metric.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "external.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "expression.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "anomaly_detection.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "query.#", "1"),
+					resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, "query.0.query", "container.cpu.utilization{k8s.deployment.name=\"httpbin\"}"),
+						resource.TestCheckResourceAttr(resourceName, "query.0.legend", "cpu.utilization {{k8s.node.name}}"),
+						resource.TestCheckResourceAttr(resourceName, "query.0.operator", ">"),
+						resource.TestCheckResourceAttr(resourceName, "query.0.warning", "70"),
+						resource.TestCheckResourceAttr(resourceName, "query.0.critical", ""),
+					),
+				),
+			},
+			// Test: Update
+			{
+				Config: testAccMackerelMonitorConfigQueryUpdated(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMackerelMonitorExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "memo", "This monitor is managed by Terraform."),
+					resource.TestCheckResourceAttr(resourceName, "is_mute", "true"),
+					resource.TestCheckResourceAttr(resourceName, "notification_interval", "30"),
+					resource.TestCheckResourceAttr(resourceName, "host_metric.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "connectivity.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "service_metric.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "external.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "expression.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "anomaly_detection.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "query.#", "1"),
+					resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, "query.0.query", "container.cpu.utilization{k8s.deployment.name=\"httpbin\"}"),
+						resource.TestCheckResourceAttr(resourceName, "query.0.legend", "cpu.utilization {{k8s.node.name}}"),
+						resource.TestCheckResourceAttr(resourceName, "query.0.operator", ">"),
+						resource.TestCheckResourceAttr(resourceName, "query.0.warning", "70"),
+						resource.TestCheckResourceAttr(resourceName, "query.0.critical", "90"),
 					),
 				),
 			},
@@ -754,4 +836,36 @@ resource "mackerel_monitor" "foo" {
   }
 }
 `, rand, rand, name)
+}
+
+func testAccMackerelMonitorConfigQuery(name string) string {
+	return fmt.Sprintf(`
+resource "mackerel_monitor" "foo" {
+  name = "%s"
+  query {
+    query = "container.cpu.utilization{k8s.deployment.name=\"httpbin\"}"
+    legend = "cpu.utilization {{k8s.node.name}}"
+    operator = ">"
+    warning = "70"
+  }
+}
+`, name)
+}
+
+func testAccMackerelMonitorConfigQueryUpdated(name string) string {
+	return fmt.Sprintf(`
+resource "mackerel_monitor" "foo" {
+  name = "%s"
+  memo = "This monitor is managed by Terraform."
+  is_mute = true
+  notification_interval = 30
+  query {
+    query = "container.cpu.utilization{k8s.deployment.name=\"httpbin\"}"
+    legend = "cpu.utilization {{k8s.node.name}}"
+    operator = ">"
+    warning = "70"
+    critical = "90"
+  }
+}
+`, name)
 }

--- a/mackerel/resource_mackerel_monitor_test.go
+++ b/mackerel/resource_mackerel_monitor_test.go
@@ -514,7 +514,7 @@ func TestAccMackerelMonitor_Query(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "anomaly_detection.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "query.#", "1"),
 					resource.ComposeTestCheckFunc(
-						resource.TestCheckResourceAttr(resourceName, "query.0.query", "container.cpu.utilization{k8s.deployment.name=\"httpbin\"}"),
+						resource.TestCheckResourceAttr(resourceName, "query.0.query", "container.cpu.utilization{k8s.deployment.name=\"nginx\"}"),
 						resource.TestCheckResourceAttr(resourceName, "query.0.legend", "cpu.utilization {{k8s.node.name}}"),
 						resource.TestCheckResourceAttr(resourceName, "query.0.operator", ">"),
 						resource.TestCheckResourceAttr(resourceName, "query.0.warning", "70"),
@@ -860,7 +860,7 @@ resource "mackerel_monitor" "foo" {
   is_mute = true
   notification_interval = 30
   query {
-    query = "container.cpu.utilization{k8s.deployment.name=\"httpbin\"}"
+    query = "container.cpu.utilization{k8s.deployment.name=\"nginx\"}"
     legend = "cpu.utilization {{k8s.node.name}}"
     operator = ">"
     warning = "70"

--- a/mackerel/structure_flattens.go
+++ b/mackerel/structure_flattens.go
@@ -64,6 +64,9 @@ func flattenMonitor(monitor mackerel.Monitor, d *schema.ResourceData) (diags dia
 	if v, ok := monitor.(*mackerel.MonitorAnomalyDetection); ok {
 		diags = flattenMonitorAnomalyDetection(v, d)
 	}
+	if v, ok := monitor.(*mackerel.MonitorQuery); ok {
+		diags = flatternMonitorQuery(v, d)
+	}
 	return diags
 }
 
@@ -201,6 +204,25 @@ func flattenMonitorAnomalyDetection(monitor *mackerel.MonitorAnomalyDetection, d
 			"scopes":               flattenStringListToSet(normalizedScopes),
 		},
 	})
+	return diags
+}
+
+func flatternMonitorQuery(monitor *mackerel.MonitorQuery, d *schema.ResourceData) (diags diag.Diagnostics) {
+	d.Set("name", monitor.Name)
+	d.Set("memo", monitor.Memo)
+	d.Set("is_mute", monitor.IsMute)
+	d.Set("notification_interval", monitor.NotificationInterval)
+
+	d.Set("query", []map[string]any{
+		{
+			"query":    monitor.Query,
+			"operator": monitor.Operator,
+			"legend":   monitor.Legend,
+			"warning":  parseFloat64ToString(monitor.Warning),
+			"critical": parseFloat64ToString(monitor.Critical),
+		},
+	})
+
 	return diags
 }
 


### PR DESCRIPTION
Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS="'TestAcc(DataSourceMackerelMonitorQuery|MackerelMonitor_Query)'"

TF_ACC=1 go test -v ./mackerel/... -run 'TestAcc(DataSourceMackerelMonitorQuery|MackerelMonitor_Query)' -timeout 120m
=== RUN   TestAccDataSourceMackerelMonitorQuery
=== PAUSE TestAccDataSourceMackerelMonitorQuery
=== RUN   TestAccMackerelMonitor_Query
=== PAUSE TestAccMackerelMonitor_Query
=== CONT  TestAccDataSourceMackerelMonitorQuery
=== CONT  TestAccMackerelMonitor_Query
--- PASS: TestAccDataSourceMackerelMonitorQuery (4.40s)
--- PASS: TestAccMackerelMonitor_Query (7.73s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel 8.363s
```
