### PR TITLE
Labeled metrics for dashboards

### DIFF
--- a/docs/data-sources/dashboard.md
+++ b/docs/data-sources/dashboard.md
@@ -42,6 +42,9 @@ data "mackerel_dashboard" "this" {
     * `name` - The name of graph.
   * `expression` - The expression graph.
     * `expression` - The expression for graphs.
+  * `query` - The query graph.
+    * `query` - The PromQL-style query.
+    * `legend` - The query legend.
   * `range` - The display period for graphs. If unspecified, it will be variable and the display period can be changed from the controller displayed at the top of the dashboard.
     * `relative` - （The period from (current time + `offset` - `period`) to (current time + `offset`) is displayed. Negative values for `offset` can be used to display graphs for a specified period in the past.
       * `period` - Duration (seconds).
@@ -65,6 +68,9 @@ data "mackerel_dashboard" "this" {
       * `name` - The name of metric.
     * `expression` - The expression metric.
       * `expression` - The expression for metric.
+    * `query` - The query metric.
+      * `query` - The PromQL-style query.
+      * `legend` - The query legend.
   * `fraction_size` - Number of decimal places to display (0-16).
   * `suffix` - Units to be displayed after the numerical value.
   * `layout` - The coordinates are specified with the upper left corner of the widget display area as the origin (x = 0, y = 0), with the x axis in the right direction and they axis in the down direction as the positive direction.

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -155,6 +155,9 @@ resource "mackerel_dashboard" "alert_status" {
   * `name` - (Required) The name of graph.
 * `expression` - The expression graph.
   * `expression` - (Required) The expression for graphs.
+* `query` - The query graph.
+  * `query` - (Required) The PromQL-style query.
+  * `legend` - The query legend.
 * `range` - The display period for graphs. If unspecified, it will be variable and thedisplay period can be changed from the controller displayed at the top of the dashboard.
   * `relative` - （The period from (current time + `offset` - `period`) to (current time + `offset`) is displayed. Negative values for `offset` can be used to display graphs for a specified period in the past.
     * `period` - (Required) Duration (seconds).
@@ -180,6 +183,9 @@ resource "mackerel_dashboard" "alert_status" {
     * `name` - (Required) The name of metric.
   * `expression` - The expression metric.
     * `expression` - (Required) The expression for metric.
+  * `query` - The query metric.
+    * `query` - (Required) The PromQL-style query.
+    * `legend` - The query legend.
 * `fraction_size` - Number of decimal places to display (0-16).
 * `suffix` - Units to be displayed after the numerical value.
 * `layout` - (Required) The coordinates are specified with the upper left corner of the widget display area as the origin (x = 0, y = 0), with the x axis in the right direction and they axis in the down direction as the positive direction.

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,11 @@ go 1.21
 
 require (
 	github.com/golangci/golangci-lint v1.50.1
+	github.com/hashicorp/terraform-plugin-framework v1.8.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-mux v0.16.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
-	github.com/mackerelio/mackerel-client-go v0.31.0
+	github.com/mackerelio/mackerel-client-go v0.33.0
 )
 
 require (
@@ -91,8 +92,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.21.0 // indirect
 	github.com/hashicorp/terraform-json v0.22.1 // indirect
-	github.com/hashicorp/terraform-plugin-framework v1.8.0 // indirect
-	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -342,8 +342,6 @@ github.com/hashicorp/terraform-json v0.22.1 h1:xft84GZR0QzjPVWs4lRUwvTcPnegqlyS7
 github.com/hashicorp/terraform-json v0.22.1/go.mod h1:JbWSQCLFSXFFhg42T7l9iJwdGXBYV8fmmD6o/ML4p3A=
 github.com/hashicorp/terraform-plugin-framework v1.8.0 h1:P07qy8RKLcoBkCrY2RHJer5AEvJnDuXomBgou6fD8kI=
 github.com/hashicorp/terraform-plugin-framework v1.8.0/go.mod h1:/CpTukO88PcL/62noU7cuyaSJ4Rsim+A/pa+3rUVufY=
-github.com/hashicorp/terraform-plugin-framework-validators v0.12.0 h1:HOjBuMbOEzl7snOdOoUfE2Jgeto6JOjLVQ39Ls2nksc=
-github.com/hashicorp/terraform-plugin-framework-validators v0.12.0/go.mod h1:jfHGE/gzjxYz6XoUwi/aYiiKrJDeutQNUtGQXkaHklg=
 github.com/hashicorp/terraform-plugin-go v0.23.0 h1:AALVuU1gD1kPb48aPQUjug9Ir/125t+AAurhqphJ2Co=
 github.com/hashicorp/terraform-plugin-go v0.23.0/go.mod h1:1E3Cr9h2vMlahWMbsSEcNrOCxovCZhOOIXjFHbjc/lQ=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=
@@ -422,8 +420,8 @@ github.com/leonklingele/grouper v1.1.0/go.mod h1:uk3I3uDfi9B6PeUjsCKi6ndcf63Uy7s
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lufeee/execinquery v1.2.1 h1:hf0Ems4SHcUGBxpGN7Jz78z1ppVkP/837ZlETPCEtOM=
 github.com/lufeee/execinquery v1.2.1/go.mod h1:EC7DrEKView09ocscGHC+apXMIaorh4xqSxS/dy8SbM=
-github.com/mackerelio/mackerel-client-go v0.31.0 h1:oUBwuJzZkvhSFf7C7zpOBej8jM0kITUz7eVMAINIfO4=
-github.com/mackerelio/mackerel-client-go v0.31.0/go.mod h1:b4qVMQi+w4rxtKQIFycLWXNBtIi9d0r571RzYmg/aXo=
+github.com/mackerelio/mackerel-client-go v0.33.0 h1:dMv0pyR3Exvtxxq3l7xzGF6D/5ky2Jgftzmp4aAoFYg=
+github.com/mackerelio/mackerel-client-go v0.33.0/go.mod h1:b4qVMQi+w4rxtKQIFycLWXNBtIi9d0r571RzYmg/aXo=
 github.com/magiconair/properties v1.8.6 h1:5ibWZ6iY0NctNGWo87LalDlEZ6R41TqbbDamhfG/Qzo=
 github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/maratori/testableexamples v1.0.0 h1:dU5alXRrD8WKSjOUnmJZuzdxWOEQ57+7s93SLMxb2vI=

--- a/mackerel/data_source_mackerel_dashboard.go
+++ b/mackerel/data_source_mackerel_dashboard.go
@@ -112,6 +112,22 @@ var dashboardMetricDataResource = &schema.Resource{
 				},
 			},
 		},
+		"query": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"query": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"legend": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
 	},
 }
 
@@ -210,6 +226,22 @@ func dataSourceMackerelDashboard() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"expression": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"query": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"query": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"legend": {
 										Type:     schema.TypeString,
 										Computed: true,
 									},

--- a/mackerel/data_source_mackerel_dashboard_test.go
+++ b/mackerel/data_source_mackerel_dashboard_test.go
@@ -24,7 +24,7 @@ func TestAccDataSourceMackerelDashboardGraph(t *testing.T) {
 					resource.TestCheckResourceAttr(dsName, "title", title),
 					resource.TestCheckResourceAttr(dsName, "memo", "This dashboard is managed by Terraform."),
 					resource.TestCheckResourceAttr(dsName, "url_path", rand),
-					resource.TestCheckResourceAttr(dsName, "graph.#", "2"),
+					resource.TestCheckResourceAttr(dsName, "graph.#", "3"),
 					resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr(dsName, "graph.0.title", "test graph role"),
 						resource.TestCheckResourceAttr(dsName, "graph.0.role.0.role_fullname", fmt.Sprintf("tf-service-%s-include:tf-role-%s-include", rand, rand)),
@@ -43,6 +43,15 @@ func TestAccDataSourceMackerelDashboardGraph(t *testing.T) {
 						resource.TestCheckResourceAttr(dsName, "graph.1.layout.0.y", "32"),
 						resource.TestCheckResourceAttr(dsName, "graph.1.layout.0.width", "10"),
 						resource.TestCheckResourceAttr(dsName, "graph.1.layout.0.height", "8"),
+						resource.TestCheckResourceAttr(dsName, "graph.2.title", "test graph query"),
+						resource.TestCheckResourceAttr(dsName, "graph.2.query.0.query", "container.cpu.utilization{k8s.deployment.name=\"httpbin\"}"),
+						resource.TestCheckResourceAttr(dsName, "graph.2.query.0.legend", "{{k8s.node.name}}"),
+						resource.TestCheckResourceAttr(dsName, "graph.2.range.0.relative.0.period", "3600"),
+						resource.TestCheckResourceAttr(dsName, "graph.2.range.0.relative.0.offset", "1800"),
+						resource.TestCheckResourceAttr(dsName, "graph.2.layout.0.x", "0"),
+						resource.TestCheckResourceAttr(dsName, "graph.2.layout.0.y", "52"),
+						resource.TestCheckResourceAttr(dsName, "graph.2.layout.0.width", "10"),
+						resource.TestCheckResourceAttr(dsName, "graph.2.layout.0.height", "8"),
 					),
 				),
 			},
@@ -72,6 +81,27 @@ func TestAccDataSourceMackerelDashboardValue(t *testing.T) {
 						resource.TestCheckResourceAttr(dsName, "value.0.metric.0.expression.0.expression", fmt.Sprintf("role(tf-service-%s-include:tf-role-%s-include, loadavg5)", rand, rand)),
 						resource.TestCheckResourceAttr(dsName, "value.0.fraction_size", "5"),
 						resource.TestCheckResourceAttr(dsName, "value.0.suffix", "test suffix"),
+						resource.TestCheckResourceAttr(dsName, "value.0.layout.0.x", "3"),
+						resource.TestCheckResourceAttr(dsName, "value.0.layout.0.y", "15"),
+						resource.TestCheckResourceAttr(dsName, "value.0.layout.0.width", "3"),
+						resource.TestCheckResourceAttr(dsName, "value.0.layout.0.height", "4"),
+					),
+				),
+			},
+			{
+				Config: testAccDataSourceMackerelDashboardConfigValue_Query(rand, title),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dsName, "id"),
+					resource.TestCheckResourceAttr(dsName, "title", title),
+					resource.TestCheckResourceAttr(dsName, "memo", "This dashboard is managed by Terraform."),
+					resource.TestCheckResourceAttr(dsName, "url_path", rand),
+					resource.TestCheckResourceAttr(dsName, "value.#", "1"),
+					resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(dsName, "value.0.title", "test value query"),
+						resource.TestCheckResourceAttr(dsName, "value.0.metric.0.query.0.query", "avg(avg_over_time(container.cpu.utilization{k8s.deployment.name=\"httpbin\"}[1h]))"),
+						resource.TestCheckResourceAttr(dsName, "value.0.metric.0.query.0.legend", "average utilization"),
+						resource.TestCheckResourceAttr(dsName, "value.0.fraction_size", "10"),
+						resource.TestCheckResourceAttr(dsName, "value.0.suffix", "test query suffix"),
 						resource.TestCheckResourceAttr(dsName, "value.0.layout.0.x", "3"),
 						resource.TestCheckResourceAttr(dsName, "value.0.layout.0.y", "15"),
 						resource.TestCheckResourceAttr(dsName, "value.0.layout.0.width", "3"),
@@ -204,6 +234,25 @@ resource "mackerel_dashboard" "foo" {
       height = 8
     }
   }
+  graph {
+    title = "test graph query"
+    query {
+      query = "container.cpu.utilization{k8s.deployment.name=\"httpbin\"}"
+      legend = "{{k8s.node.name}}"
+    }
+    range {
+      relative {
+        period = 3600
+        offset = 1800
+      }
+    }
+    layout {
+      x = 0
+      y = 52
+      width = 10
+      height = 8
+    }
+  }
 }
 
 
@@ -237,6 +286,46 @@ resource "mackerel_dashboard" "foo" {
     }
     fraction_size = 5
     suffix = "test suffix"
+    layout {
+      x = 3
+      y = 15
+      width = 3
+      height = 4
+    }
+  }
+}
+
+data "mackerel_dashboard" "foo" {
+  id = mackerel_dashboard.foo.id
+}
+`, rand, rand, title, rand)
+}
+
+func testAccDataSourceMackerelDashboardConfigValue_Query(rand, title string) string {
+	return fmt.Sprintf(`
+resource "mackerel_service" "include" {
+  name = "tf-service-%s-include"
+}
+	
+resource "mackerel_role" "include" {
+  service = mackerel_service.include.name
+  name    = "tf-role-%s-include"
+}
+
+resource "mackerel_dashboard" "foo" {
+  title = "%s"
+  memo = "This dashboard is managed by Terraform."
+  url_path = "%s"
+  value {
+    title = "test value query"
+    metric {
+      query {
+        query = "avg(avg_over_time(container.cpu.utilization{k8s.deployment.name=\"httpbin\"}[1h]))"
+        legend = "average utilization"
+      }
+    }
+    fraction_size = 10
+    suffix = "test query suffix"
     layout {
       x = 3
       y = 15

--- a/mackerel/structure_flattens.go
+++ b/mackerel/structure_flattens.go
@@ -440,6 +440,17 @@ func flattenDashboard(dashboard *mackerel.Dashboard, d *schema.ResourceData) (di
 					"range":      []map[string][]map[string]int64{g_range},
 					"layout":     []map[string]int{layout},
 				})
+			case "query":
+				query := map[string]interface{}{
+					"query":  widget.Graph.Query,
+					"legend": widget.Graph.Legend,
+				}
+				graphs = append(graphs, map[string]interface{}{
+					"title":  widget.Title,
+					"query":  []map[string]interface{}{query},
+					"range":  []map[string][]map[string]int64{g_range},
+					"layout": []map[string]int{layout},
+				})
 			}
 		case "value":
 			var metric map[string][]map[string]string
@@ -462,6 +473,13 @@ func flattenDashboard(dashboard *mackerel.Dashboard, d *schema.ResourceData) (di
 				metric = map[string][]map[string]string{
 					"expression": {{
 						"expression": widget.Metric.Expression,
+					}},
+				}
+			case "query":
+				metric = map[string][]map[string]string{
+					"query": {{
+						"query":  widget.Metric.Query,
+						"legend": widget.Metric.Legend,
 					}},
 				}
 			}


### PR DESCRIPTION
Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS="'TestAcc(DataSource)?MackerelDashboard(Graph|Value)'"
TF_ACC=1 go test -v ./mackerel/... -run 'TestAcc(DataSource)?MackerelDashboard(Graph|Value)' -timeout 120m
=== RUN   TestAccDataSourceMackerelDashboardGraph
=== PAUSE TestAccDataSourceMackerelDashboardGraph
=== RUN   TestAccDataSourceMackerelDashboardValue
=== PAUSE TestAccDataSourceMackerelDashboardValue
=== RUN   TestAccMackerelDashboardGraph
=== PAUSE TestAccMackerelDashboardGraph
=== RUN   TestAccMackerelDashboardValue
=== PAUSE TestAccMackerelDashboardValue
=== CONT  TestAccDataSourceMackerelDashboardGraph
=== CONT  TestAccMackerelDashboardGraph
=== CONT  TestAccDataSourceMackerelDashboardValue
=== CONT  TestAccMackerelDashboardValue
--- PASS: TestAccDataSourceMackerelDashboardGraph (5.64s)
--- PASS: TestAccDataSourceMackerelDashboardValue (8.75s)
--- PASS: TestAccMackerelDashboardValue (9.25s)
--- PASS: TestAccMackerelDashboardGraph (9.65s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel 10.662s
...
```
