### PR TITLE
Allow ElastiCache to retire automatically

### DIFF
--- a/docs/data-sources/aws_integration.md
+++ b/docs/data-sources/aws_integration.md
@@ -39,4 +39,4 @@ data "mackerel_aws_integration" "foo" {
 * `enable` - Whether integration settings are enabled. Default is `true`.
 * `role` - The set of monitoring target’s service name or role name.
 * `excluded_metrics` - 	Metrics to exclude from integration.
-* `retire_automatically` - (EC2 only) Whether automatic retirement is enabled. 
+* `retire_automatically` - (EC2, RDS and ElastiCache only) Whether automatic retirement is enabled. 

--- a/docs/resources/aws_integration.md
+++ b/docs/resources/aws_integration.md
@@ -75,7 +75,7 @@ resource "mackerel_aws_integration" "baz" {
 * `enable` - Whether integration settings are enabled. Default is `true`.
 * `role` - The set of monitoring target’s service name or role name.
 * `excluded_metrics` - 	Metrics to exclude from integration.
-* `retire_automatically` - (EC2 only) Whether automatic retirement is enabled. 
+* `retire_automatically` - (EC2, RDS and ElastiCache only) Whether automatic retirement is enabled. 
 
 ## Attributes Reference
 

--- a/mackerel/data_source_mackerel_aws_integration.go
+++ b/mackerel/data_source_mackerel_aws_integration.go
@@ -107,7 +107,7 @@ func dataSourceMackerelAWSIntegration() *schema.Resource {
 			},
 		},
 	}
-	var supportedRetireAutomatically = map[string]bool{"ec2": true, "rds": true}
+	var supportedRetireAutomatically = map[string]bool{"ec2": true, "rds": true, "elasticache": true}
 	for schemaKey := range awsIntegrationServicesKey {
 		if supportedRetireAutomatically[schemaKey] {
 			resource.Schema[schemaKey] = awsIntegrationServiceDataSchemaWithRetireAutomatically

--- a/mackerel/resource_mackerel_aws_integration.go
+++ b/mackerel/resource_mackerel_aws_integration.go
@@ -149,7 +149,7 @@ func resourceMackerelAWSIntegration() *schema.Resource {
 			},
 		},
 	}
-	var supportedRetireAutomatically = map[string]bool{"ec2": true, "rds": true}
+	var supportedRetireAutomatically = map[string]bool{"ec2": true, "rds": true, "elasticache": true}
 	for schemaKey := range awsIntegrationServicesKey {
 		if supportedRetireAutomatically[schemaKey] {
 			resource.Schema[schemaKey] = awsIntegrationServiceSchemaWithRetireAutomatically
@@ -231,7 +231,7 @@ func expandUpdateAWSIntegrationParam(d *schema.ResourceData) *mackerel.UpdateAWS
 }
 
 func expandAWSIntegrationServicesSet(d *schema.ResourceData) map[string]*mackerel.AWSIntegrationService {
-	var supportedRetireAutomatically = map[string]bool{"ec2": true, "rds": true}
+	var supportedRetireAutomatically = map[string]bool{"ec2": true, "rds": true, "elasticache": true}
 	services := make(map[string]*mackerel.AWSIntegrationService)
 	for schemaKey, mapKey := range awsIntegrationServicesKey {
 		if _, ok := d.GetOk(schemaKey); ok {

--- a/mackerel/structure_flattens.go
+++ b/mackerel/structure_flattens.go
@@ -342,7 +342,7 @@ func flattenAWSIntegration(awsIntegration *mackerel.AWSIntegration, d *schema.Re
 	d.Set("included_tags", awsIntegration.IncludedTags)
 	d.Set("excluded_tags", awsIntegration.ExcludedTags)
 
-	var supportedRetireAutomatically = map[string]bool{"EC2": true, "RDS": true}
+	var supportedRetireAutomatically = map[string]bool{"EC2": true, "RDS": true, "ElastiCache": true}
 
 	awsIntegration.Services = deleteAWSIntegrationDisableService(awsIntegration.Services)
 	for key, service := range awsIntegration.Services {


### PR DESCRIPTION
Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (5.32s)
PASS
ok  	github.com/mackerelio-labs/terraform-provider-mackerel/mackerel	5.680s
```
