### PR TITLE
Add docs for monitors with a query

### DIFF
--- a/docs/data-sources/monitor.md
+++ b/docs/data-sources/monitor.md
@@ -68,6 +68,12 @@ data "mackerel_monitor" "this" {
   * `operator` - The comparison operator to determines the conditions that state whether the designated variable is either big or small. The observed value is on the left of the operator and the designated value is on the right.
   * `warning` - The threshold that generates a warning alert.
   * `critical` - The threshold that generates a critical alert.
+* `query` - The settings for the monitor of query monitoring.
+  * `query` - The PromQL-style query.
+  * `legend` - The query legend.
+  * `operator` - The comparison operator to determines the conditions that state whether the designated variable is either big or small. The observed value is on the left of the operator and the designated value is on the right.
+  * `warning` - The threshold that generates a warning alert.
+  * `critical` - The threshold that generates a critical alert.
 * `anomaly_detection` - The settings for the monitor of  Anomaly Detection for roles.
   * `scopes` - Expression of the monitoring target. Only valid for graph sequences that become one line.
   * `warning_sensitivity` - The sensitivity to generates warning alerts.

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -93,6 +93,22 @@ resource "mackerel_monitor" "role_avg" {
 }
 ```
 
+### query
+
+```terraform
+resource "mackerel_monitor" "httpbin_load" {
+  name = "httpbin load per node"
+
+  query {
+    query = "sum by (k8s.node.name) (container.cpu.utilization{k8s.deployment.name=\"httpbin\"})"
+    legend = "cpu.utilization {{k8s.node.name}}"
+    operator = ">"
+    warning = "0.7"
+    critical = "0.9"
+  }
+}
+```
+
 ### anomaly_detection
 
 ```terraform
@@ -166,6 +182,14 @@ The following arguments are required:
 ### expression
 
 * `expression` - (Required)
+* `operator` - (Required) The comparison operator to determines the conditions that state whether the designated variable is either big or small. The observed value is on the left of the operator and the designated value is on the right. Valid values are `>` and `<`.
+* `warning` - (Required, at least one of `warning` or `critical`) The threshold that generates a warning alert.
+* `critical` - (Required, at least one of `warning` or `critical`) The threshold that generates a critical alert.
+
+### query
+
+* `query` - (Required) The PromQL-style query.
+* `legend` - The query legend.
 * `operator` - (Required) The comparison operator to determines the conditions that state whether the designated variable is either big or small. The observed value is on the left of the operator and the designated value is on the right. Valid values are `>` and `<`.
 * `warning` - (Required, at least one of `warning` or `critical`) The threshold that generates a warning alert.
 * `critical` - (Required, at least one of `warning` or `critical`) The threshold that generates a critical alert.


### PR DESCRIPTION
This pull request adds the documentation that was missing in PR #201.

Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ . make testacc TESTS=TestAccXXX

...
```
Since this pull request only involves documentation changes and does not include any code modifications, acceptance tests are not required.
