### PR TITLE
Add support for AlertStatusOnGone in mackerel_monitor connectivity resource

### DIFF
--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -149,6 +149,7 @@ The following arguments are required:
 
 * `scopes` - The set of monitoring target’s service name or role name.
 * `exclude_scopes` - The set of monitoring exclusion target’s service name or role name.
+* `alert_status_on_gone` - The alert status when the monitoring target is gone. Valid values are `CRITICAL` and `WARNING`. Default is `CRITICAL`.
 
 ### service_metric
 

--- a/mackerel/data_source_mackerel_monitor.go
+++ b/mackerel/data_source_mackerel_monitor.go
@@ -91,6 +91,10 @@ func dataSourceMackerelMonitor() *schema.Resource {
 							Computed: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						"alert_status_on_gone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/mackerel/data_source_mackerel_monitor_test.go
+++ b/mackerel/data_source_mackerel_monitor_test.go
@@ -70,6 +70,7 @@ func TestAccDataSourceMackerelMonitorConnectivity(t *testing.T) {
 					resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr(dsName, "connectivity.0.scopes.#", "2"),
 						resource.TestCheckResourceAttr(dsName, "connectivity.0.exclude_scopes.#", "2"),
+						resource.TestCheckResourceAttr(dsName, "connectivity.0.alert_status_on_gone", "WARNING"),
 					),
 					resource.TestCheckResourceAttr(dsName, "service_metric.#", "0"),
 					resource.TestCheckResourceAttr(dsName, "external.#", "0"),
@@ -361,6 +362,7 @@ resource "mackerel_monitor" "foo" {
     exclude_scopes = [
       mackerel_service.not_scoped.name,
       mackerel_role.not_scoped.id]
+    alert_status_on_gone = "WARNING"
   }
 }
 

--- a/mackerel/resource_mackerel_monitor.go
+++ b/mackerel/resource_mackerel_monitor.go
@@ -121,6 +121,12 @@ func resourceMackerelMonitor() *schema.Resource {
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						"alert_status_on_gone": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "CRITICAL",
+							ValidateFunc: validation.StringInSlice([]string{"CRITICAL", "WARNING"}, false),
+						},
 					},
 				},
 			},
@@ -478,6 +484,7 @@ func expandMonitorConnectivity(d *schema.ResourceData) *mackerel.MonitorConnecti
 		NotificationInterval: uint64(d.Get("notification_interval").(int)),
 		Scopes:               expandStringListFromSet(d.Get("connectivity.0.scopes").(*schema.Set)),
 		ExcludeScopes:        expandStringListFromSet(d.Get("connectivity.0.exclude_scopes").(*schema.Set)),
+		AlertStatusOnGone:    d.Get("connectivity.0.alert_status_on_gone").(string),
 	}
 	return monitor
 }

--- a/mackerel/resource_mackerel_monitor_test.go
+++ b/mackerel/resource_mackerel_monitor_test.go
@@ -112,6 +112,7 @@ func TestAccMackerelMonitor_Connectivity(t *testing.T) {
 					resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr(resourceName, "connectivity.0.scopes.#", "0"),
 						resource.TestCheckResourceAttr(resourceName, "connectivity.0.exclude_scopes.#", "0"),
+						resource.TestCheckResourceAttr(resourceName, "connectivity.0.alert_status_on_gone", "CRITICAL"),
 					),
 					resource.TestCheckResourceAttr(resourceName, "service_metric.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "external.#", "0"),
@@ -134,6 +135,7 @@ func TestAccMackerelMonitor_Connectivity(t *testing.T) {
 					resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr(resourceName, "connectivity.0.scopes.#", "2"),
 						resource.TestCheckResourceAttr(resourceName, "connectivity.0.exclude_scopes.#", "2"),
+						resource.TestCheckResourceAttr(resourceName, "connectivity.0.alert_status_on_gone", "WARNING"),
 					),
 					resource.TestCheckResourceAttr(resourceName, "service_metric.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "external.#", "0"),
@@ -665,6 +667,7 @@ resource "mackerel_monitor" "foo" {
     exclude_scopes = [
       mackerel_service.not_scoped.name,
       mackerel_role.not_scoped.id]
+    alert_status_on_gone = "WARNING"
   }
 }
 `, rand, rand, rand, rand, name)

--- a/mackerel/structure_flattens.go
+++ b/mackerel/structure_flattens.go
@@ -115,6 +115,7 @@ func flattenMonitorConnectivity(monitor *mackerel.MonitorConnectivity, d *schema
 		{
 			"scopes":         flattenStringListToSet(normalizedScopes),
 			"exclude_scopes": flattenStringListToSet(normalizedExcludeScopes),
+			"alert_status_on_gone": monitor.AlertStatusOnGone,
 		},
 	})
 	return diags

--- a/mackerel/structure_flattens.go
+++ b/mackerel/structure_flattens.go
@@ -113,8 +113,8 @@ func flattenMonitorConnectivity(monitor *mackerel.MonitorConnectivity, d *schema
 	}
 	d.Set("connectivity", []map[string]interface{}{
 		{
-			"scopes":         flattenStringListToSet(normalizedScopes),
-			"exclude_scopes": flattenStringListToSet(normalizedExcludeScopes),
+			"scopes":               flattenStringListToSet(normalizedScopes),
+			"exclude_scopes":       flattenStringListToSet(normalizedExcludeScopes),
 			"alert_status_on_gone": monitor.AlertStatusOnGone,
 		},
 	})


### PR DESCRIPTION
I added `mackerel_monitor.connectivity.0.alert_status_on_gone` to support `AlertStatusOnGone` for connectivity monitor.
https://mackerel.io/ja/api-docs/entry/monitors#create:~:text=%E3%83%AB%E3%83%BC%E3%83%AB%E3%81%AE%E3%83%A1%E3%83%A2%E3%80%82-,alertStatusOnGone,-string

Please review the code :pray:

Output from acceptance testing:

```console
$ make testacc TESTS=TestAccMackerelMonitor_Connectivity
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelMonitor_Connectivity -timeout 120m
=== RUN   TestAccMackerelMonitor_Connectivity
=== PAUSE TestAccMackerelMonitor_Connectivity
=== CONT  TestAccMackerelMonitor_Connectivity
--- PASS: TestAccMackerelMonitor_Connectivity (6.38s)
PASS
ok  	github.com/mackerelio-labs/terraform-provider-mackerel/mackerel	6.765s

$ make testacc TESTS=TestAccDataSourceMackerelMonitorConnectivity
TF_ACC=1 go test -v ./mackerel/... -run TestAccDataSourceMackerelMonitorConnectivity -timeout 120m
=== RUN   TestAccDataSourceMackerelMonitorConnectivity
=== PAUSE TestAccDataSourceMackerelMonitorConnectivity
=== CONT  TestAccDataSourceMackerelMonitorConnectivity
--- PASS: TestAccDataSourceMackerelMonitorConnectivity (5.23s)
PASS
ok  	github.com/mackerelio-labs/terraform-provider-mackerel/mackerel	5.620s
```
