### PR TITLE
Reimplement service metric names with tf-framework

### DIFF
--- a/internal/mackerel/service_metric_names.go
+++ b/internal/mackerel/service_metric_names.go
@@ -1,0 +1,44 @@
+package mackerel
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type ServiceMetricNamesModel struct {
+	ID          types.String   `tfsdk:"id"`
+	Name        types.String   `tfsdk:"name"`
+	MetricNames []types.String `tfsdk:"metric_names"`
+	Prefix      types.String   `tfsdk:"prefix"`
+}
+
+func ReadServiceMetricNames(ctx context.Context, client *Client, state ServiceMetricNamesModel) (ServiceMetricNamesModel, error) {
+	return readServiceMetricNamesInner(ctx, client, state)
+}
+
+type serviceMetricNamesReader interface {
+	ListServiceMetricNames(string) ([]string, error)
+}
+
+func readServiceMetricNamesInner(_ context.Context, client serviceMetricNamesReader, state ServiceMetricNamesModel) (ServiceMetricNamesModel, error) {
+	name := state.Name.ValueString()
+	prefix := state.Prefix.ValueString()
+
+	data := state
+	data.ID = types.StringValue(name + ":" + prefix)
+
+	names, err := client.ListServiceMetricNames(name)
+	if err != nil {
+		return data, err
+	}
+
+	data.MetricNames = make([]types.String, 0, len(names))
+	for _, name := range names {
+		if strings.HasPrefix(name, prefix) {
+			data.MetricNames = append(data.MetricNames, types.StringValue(name))
+		}
+	}
+	return data, nil
+}

--- a/internal/mackerel/service_metric_names_test.go
+++ b/internal/mackerel/service_metric_names_test.go
@@ -1,0 +1,92 @@
+package mackerel
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type serviceMetricNamesReaderFunc func(string) ([]string, error)
+
+func (f serviceMetricNamesReaderFunc) ListServiceMetricNames(name string) ([]string, error) {
+	return f(name)
+}
+
+func Test_ServiceMetricNames_read(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		inClient serviceMetricNamesReaderFunc
+		inState  ServiceMetricNamesModel
+
+		want ServiceMetricNamesModel
+	}{
+		"success": {
+			inClient: func(name string) ([]string, error) {
+				if name != "service0" {
+					return nil, fmt.Errorf("no service: %s", name)
+				}
+				return []string{
+					"metric",
+					"prefixed_metric",
+				}, nil
+			},
+			inState: ServiceMetricNamesModel{
+				Name: types.StringValue("service0"),
+			},
+
+			want: ServiceMetricNamesModel{
+				ID:   types.StringValue("service0:"),
+				Name: types.StringValue("service0"),
+				MetricNames: []types.String{
+					types.StringValue("metric"),
+					types.StringValue("prefixed_metric"),
+				},
+			},
+		},
+		"prefix": {
+			inClient: func(name string) ([]string, error) {
+				if name != "service0" {
+					return nil, fmt.Errorf("no service: %s", name)
+				}
+				return []string{
+					"metric",
+					"prefixed_metric",
+				}, nil
+			},
+			inState: ServiceMetricNamesModel{
+				Name:   types.StringValue("service0"),
+				Prefix: types.StringValue("prefixed"),
+			},
+
+			want: ServiceMetricNamesModel{
+				ID:     types.StringValue("service0:prefixed"),
+				Name:   types.StringValue("service0"),
+				Prefix: types.StringValue("prefixed"),
+				MetricNames: []types.String{
+					types.StringValue("prefixed_metric"),
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	for name, tt := range cases {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			data, err := readServiceMetricNamesInner(ctx, tt.inClient, tt.inState)
+			if err != nil {
+				t.Errorf("unexpected error: %+v", err)
+				return
+			}
+			if diff := cmp.Diff(tt.want, data); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/internal/provider/data_source_mackerel_service_metric_names.go
+++ b/internal/provider/data_source_mackerel_service_metric_names.go
@@ -1,0 +1,85 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel"
+)
+
+var (
+	_ datasource.DataSourceWithConfigure = (*mackerelServiceMetricNamesDataSource)(nil)
+)
+
+func NewMackerelServiceMetricNamesDataSource() datasource.DataSource {
+	return &mackerelServiceMetricNamesDataSource{}
+}
+
+type mackerelServiceMetricNamesDataSource struct {
+	Client *mackerel.Client
+}
+
+func (_ *mackerelServiceMetricNamesDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_service_metric_names"
+}
+
+func (_ *mackerelServiceMetricNamesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "This data source allows access to details of a specific Service metric names.",
+
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"name": schema.StringAttribute{
+				Description: "The name of the service.",
+
+				Required:   true,
+				Validators: []validator.String{mackerel.ServiceNameValidator()},
+			},
+			"prefix": schema.StringAttribute{
+				Description: "Prefix of the metric names.",
+
+				Optional: true,
+			},
+			"metric_names": schema.SetAttribute{
+				Description: "Set of the service metric names.",
+
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *mackerelServiceMetricNamesDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	client, diags := retrieveClient(ctx, req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+	d.Client = client
+}
+
+func (d *mackerelServiceMetricNamesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config mackerel.ServiceMetricNamesModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data, err := mackerel.ReadServiceMetricNames(ctx, d.Client, config)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Unable to read Service Metric Names from Service: %s", config.Name.ValueString()),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/data_source_mackerel_service_metric_names_test.go
+++ b/internal/provider/data_source_mackerel_service_metric_names_test.go
@@ -1,0 +1,27 @@
+package provider_test
+
+import (
+	"context"
+	"testing"
+
+	fwdatasource "github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider"
+)
+
+func Test_MackerelServiceMetricNamesDataSource_schema(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	req := fwdatasource.SchemaRequest{}
+	resp := &fwdatasource.SchemaResponse{}
+	provider.NewMackerelServiceMetricNamesDataSource().Schema(ctx, req, resp)
+	if resp.Diagnostics.HasError() {
+		t.Errorf("schema method: %+v", resp.Diagnostics)
+		return
+	}
+
+	if diags := resp.Schema.ValidateImplementation(ctx); diags.HasError() {
+		t.Errorf("schema validation: %+v", diags)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -90,6 +90,7 @@ func (m *mackerelProvider) Resources(context.Context) []func() resource.Resource
 func (m *mackerelProvider) DataSources(context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
 		NewMackerelServiceDataSource,
+		NewMackerelServiceMetricNamesDataSource,
 	}
 }
 

--- a/mackerel/provider.go
+++ b/mackerel/provider.go
@@ -86,6 +86,7 @@ func protoV5ProviderServer(provider *schema.Provider) tfprotov5.ProviderServer {
 
 		// Data Sources
 		delete(provider.DataSourcesMap, "mackerel_service")
+		delete(provider.DataSourcesMap, "mackerel_service_metric_names")
 
 		mux, err := tf5muxserver.NewMuxServer(
 			context.Background(),


### PR DESCRIPTION
Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ MACKEREL_EXPERIMENTAL_TFFRAMEWORK=1 make testacc TESTS='AccDataSourceMackerelServiceMetricNames'
TF_ACC=1 go test -v ./mackerel/... -run AccDataSourceMackerelServiceMetricNames -timeout 120m
2024/06/26 18:10:02 [INFO] mackerel: use terraform-plugin-framework based implementation
=== RUN   TestAccDataSourceMackerelServiceMetricNames
=== PAUSE TestAccDataSourceMackerelServiceMetricNames
=== CONT  TestAccDataSourceMackerelServiceMetricNames
--- PASS: TestAccDataSourceMackerelServiceMetricNames (5.23s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel 6.606s
```
