### PR TITLE
Reimplement notification groups with tf-framework

### DIFF
--- a/internal/mackerel/notification_group.go
+++ b/internal/mackerel/notification_group.go
@@ -1,0 +1,201 @@
+package mackerel
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+type NotificationGroupModel struct {
+	ID                        types.String                     `tfsdk:"id"`
+	Name                      types.String                     `tfsdk:"name"`
+	NotificationLevel         types.String                     `tfsdk:"notification_level"`
+	ChildNotificationGroupIDs []types.String                   `tfsdk:"child_notification_group_ids"`
+	ChildChannelIDs           []types.String                   `tfsdk:"child_channel_ids"`
+	Monitors                  []NotificationTargetMonitorModel `tfsdk:"monitor"`
+	Services                  []NotificationTargetServiceModel `tfsdk:"service"`
+}
+type NotificationTargetMonitorModel struct {
+	ID          types.String `tfsdk:"id"`
+	SkipDefault types.Bool   `tfsdk:"skip_default"`
+}
+type NotificationTargetServiceModel struct {
+	Name types.String `tfsdk:"name"`
+}
+
+func NotificationLevelValidator() validator.String {
+	return stringvalidator.OneOf(
+		string(mackerel.NotificationLevelAll),
+		string(mackerel.NotificationLevelCritical),
+	)
+}
+
+// Reads a notification group by `id` or `name`, and returns merged state.
+func ReadNotificationGroup(_ context.Context, client *Client, data NotificationGroupModel) (NotificationGroupModel, error) {
+	ngs, err := client.FindNotificationGroups()
+	if err != nil {
+		return NotificationGroupModel{}, err
+	}
+
+	var ngIdx int
+	if !data.ID.IsNull() && !data.ID.IsUnknown() {
+		id := data.ID.ValueString()
+		ngIdx = slices.IndexFunc(ngs, func(ng *mackerel.NotificationGroup) bool {
+			return ng.ID == id
+		})
+		if ngIdx < 0 {
+			return NotificationGroupModel{}, fmt.Errorf("the ID '%s' does not match any notification group in mackerel.io", id)
+		}
+	} else if !data.Name.IsNull() && !data.Name.IsUnknown() {
+		name := data.Name.ValueString()
+		ngIdx = slices.IndexFunc(ngs, func(ng *mackerel.NotificationGroup) bool {
+			return ng.Name == name
+		})
+		if ngIdx < 0 {
+			return NotificationGroupModel{}, fmt.Errorf("the name '%s' does not match any notification group in mackerel.io", name)
+		}
+	} else {
+		return NotificationGroupModel{}, fmt.Errorf("missing name or ID")
+	}
+
+	return newNotificationGroupModel(*ngs[ngIdx]), nil
+}
+
+// Creates a notification group
+func (m *NotificationGroupModel) Create(ctx context.Context, client *Client) error {
+	return m.createInner(ctx, client)
+}
+
+type notificationGroupCreator interface {
+	CreateNotificationGroup(*mackerel.NotificationGroup) (*mackerel.NotificationGroup, error)
+}
+
+func (m *NotificationGroupModel) createInner(_ context.Context, client notificationGroupCreator) error {
+	param := m.mackerelNotificationGroup()
+	ng, err := client.CreateNotificationGroup(&param)
+	if err != nil {
+		return err
+	}
+
+	m.ID = types.StringValue(ng.ID)
+	return nil
+}
+
+// Reads the notification group
+func (m *NotificationGroupModel) Read(ctx context.Context, client *Client) error {
+	data, err := ReadNotificationGroup(ctx, client, m.ID.ValueString())
+	if err != nil {
+		return err
+	}
+
+	// merge states
+	if m.ID.ValueString() != data.ID.ValueString() {
+		return fmt.Errorf("ID cannot be updated")
+	}
+
+	m.Name = data.Name                           // required
+	m.NotificationLevel = data.NotificationLevel // has default
+
+	// optional attrs needs to preserve null on zero values
+	if m.ChildNotificationGroupIDs != nil || len(data.ChildNotificationGroupIDs) > 0 {
+		m.ChildNotificationGroupIDs = data.ChildNotificationGroupIDs
+	}
+	if m.ChildChannelIDs != nil || len(data.ChildChannelIDs) > 0 {
+		m.ChildChannelIDs = data.ChildChannelIDs
+	}
+
+	m.Monitors = data.Monitors
+	m.Services = data.Services
+
+	return nil
+}
+
+// Updates the notification group
+func (m *NotificationGroupModel) Update(_ context.Context, client *Client) error {
+	param := m.mackerelNotificationGroup()
+	if _, err := client.UpdateNotificationGroup(m.ID.ValueString(), &param); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Deletes the notification group
+func (m *NotificationGroupModel) Delete(_ context.Context, client *Client) error {
+	if _, err := client.DeleteNotificationGroup(m.ID.ValueString()); err != nil {
+		return err
+	}
+	return nil
+}
+
+// API -> Model
+func newNotificationGroupModel(ng mackerel.NotificationGroup) (data NotificationGroupModel) {
+	data.ID = types.StringValue(ng.ID)
+	data.Name = types.StringValue(ng.Name)
+	data.NotificationLevel = types.StringValue(string(ng.NotificationLevel))
+
+	data.ChildNotificationGroupIDs = make([]types.String, 0, len(ng.ChildNotificationGroupIDs))
+	for _, id := range ng.ChildNotificationGroupIDs {
+		data.ChildNotificationGroupIDs = append(data.ChildNotificationGroupIDs, types.StringValue(id))
+	}
+
+	data.ChildChannelIDs = make([]types.String, 0, len(ng.ChildChannelIDs))
+	for _, id := range ng.ChildChannelIDs {
+		data.ChildChannelIDs = append(data.ChildChannelIDs, types.StringValue(id))
+	}
+
+	data.Monitors = make([]NotificationTargetMonitorModel, 0, len(ng.Monitors))
+	for _, monitor := range ng.Monitors {
+		data.Monitors = append(data.Monitors, NotificationTargetMonitorModel{
+			ID:          types.StringValue(monitor.ID),
+			SkipDefault: types.BoolValue(monitor.SkipDefault),
+		})
+	}
+
+	data.Services = make([]NotificationTargetServiceModel, 0, len(ng.Services))
+	for _, service := range ng.Services {
+		data.Services = append(data.Services, NotificationTargetServiceModel{
+			Name: types.StringValue(service.Name),
+		})
+	}
+
+	return
+}
+
+// Model -> API
+func (m NotificationGroupModel) mackerelNotificationGroup() (ng mackerel.NotificationGroup) {
+	ng.ID = m.ID.ValueString()
+	ng.Name = m.Name.ValueString()
+	ng.NotificationLevel = mackerel.NotificationLevel(m.NotificationLevel.ValueString())
+
+	ng.ChildNotificationGroupIDs = make([]string, 0, len(m.ChildNotificationGroupIDs))
+	for _, id := range m.ChildNotificationGroupIDs {
+		ng.ChildNotificationGroupIDs = append(ng.ChildNotificationGroupIDs, id.ValueString())
+	}
+
+	ng.ChildChannelIDs = make([]string, 0, len(m.ChildChannelIDs))
+	for _, id := range m.ChildChannelIDs {
+		ng.ChildChannelIDs = append(ng.ChildChannelIDs, id.ValueString())
+	}
+
+	ng.Monitors = make([]*mackerel.NotificationGroupMonitor, 0, len(m.Monitors))
+	for _, monitor := range m.Monitors {
+		ng.Monitors = append(ng.Monitors, &mackerel.NotificationGroupMonitor{
+			ID:          monitor.ID.ValueString(),
+			SkipDefault: monitor.SkipDefault.ValueBool(),
+		})
+	}
+
+	ng.Services = make([]*mackerel.NotificationGroupService, 0, len(m.Services))
+	for _, service := range m.Services {
+		ng.Services = append(ng.Services, &mackerel.NotificationGroupService{
+			Name: service.Name.ValueString(),
+		})
+	}
+
+	return
+}

--- a/internal/mackerel/notification_group_test.go
+++ b/internal/mackerel/notification_group_test.go
@@ -1,0 +1,175 @@
+package mackerel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+func Test_NotificationGroup_Read(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		inID     string
+		inClient notificationGroupFinderFunc
+
+		wantErr bool
+		wants   NotificationGroupModel
+	}{
+		"valid": {
+			inID: "ng0",
+			inClient: func() ([]*mackerel.NotificationGroup, error) {
+				return []*mackerel.NotificationGroup{{
+					ID:                        "ng0",
+					Name:                      "notification group",
+					NotificationLevel:         mackerel.NotificationLevelAll,
+					ChildNotificationGroupIDs: []string{"cng0"},
+					ChildChannelIDs:           []string{"cc0"},
+					Monitors: []*mackerel.NotificationGroupMonitor{{
+						ID:          "monitor0",
+						SkipDefault: true,
+					}},
+					Services: []*mackerel.NotificationGroupService{{Name: "service"}},
+				}}, nil
+			},
+
+			wants: NotificationGroupModel{
+				ID:                        types.StringValue("ng0"),
+				Name:                      types.StringValue("notification group"),
+				NotificationLevel:         types.StringValue("all"),
+				ChildNotificationGroupIDs: []types.String{types.StringValue("cng0")},
+				ChildChannelIDs:           []types.String{types.StringValue("cc0")},
+				Monitors: []NotificationTargetMonitorModel{{
+					ID:          types.StringValue("monitor0"),
+					SkipDefault: types.BoolValue(true),
+				}},
+				Services: []NotificationTargetServiceModel{{Name: types.StringValue("service")}},
+			},
+		},
+		"missing": {
+			inID: "ng1",
+			inClient: func() ([]*mackerel.NotificationGroup, error) {
+				return []*mackerel.NotificationGroup{{ID: "ng0"}}, nil
+			},
+
+			wantErr: true,
+		},
+	}
+
+	ctx := context.Background()
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ng, err := readNotificationGroupInner(ctx, tt.inClient, tt.inID)
+			if (err != nil) != tt.wantErr {
+				if tt.wantErr {
+					t.Errorf("expect error, but got no error")
+				} else {
+					t.Errorf("unexpected error: %+v", err)
+				}
+				return
+			}
+
+			if diff := cmp.Diff(ng, tt.wants); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+type notificationGroupFinderFunc func() ([]*mackerel.NotificationGroup, error)
+
+func (f notificationGroupFinderFunc) FindNotificationGroups() ([]*mackerel.NotificationGroup, error) {
+	return f()
+}
+
+func Test_NotificationGroup_Create(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		in   NotificationGroupModel
+		inID string
+
+		wantReq mackerel.NotificationGroup
+		wants   NotificationGroupModel
+	}{
+		"valid": {
+			in: NotificationGroupModel{
+				ID:                        types.StringUnknown(),
+				Name:                      types.StringValue("notification group"),
+				NotificationLevel:         types.StringValue("all"),
+				ChildNotificationGroupIDs: []types.String{types.StringValue("cng0")},
+				ChildChannelIDs:           []types.String{types.StringValue("cc0")},
+				Monitors: []NotificationTargetMonitorModel{{
+					ID:          types.StringValue("monitor0"),
+					SkipDefault: types.BoolValue(true),
+				}},
+				Services: []NotificationTargetServiceModel{{Name: types.StringValue("service")}},
+			},
+			inID: "ng0",
+
+			wantReq: mackerel.NotificationGroup{
+				ID:                        "",
+				Name:                      "notification group",
+				NotificationLevel:         mackerel.NotificationLevelAll,
+				ChildNotificationGroupIDs: []string{"cng0"},
+				ChildChannelIDs:           []string{"cc0"},
+				Monitors: []*mackerel.NotificationGroupMonitor{{
+					ID:          "monitor0",
+					SkipDefault: true,
+				}},
+				Services: []*mackerel.NotificationGroupService{{Name: "service"}},
+			},
+			wants: NotificationGroupModel{
+				ID:                        types.StringValue("ng0"),
+				Name:                      types.StringValue("notification group"),
+				NotificationLevel:         types.StringValue("all"),
+				ChildNotificationGroupIDs: []types.String{types.StringValue("cng0")},
+				ChildChannelIDs:           []types.String{types.StringValue("cc0")},
+				Monitors: []NotificationTargetMonitorModel{{
+					ID:          types.StringValue("monitor0"),
+					SkipDefault: types.BoolValue(true),
+				}},
+				Services: []NotificationTargetServiceModel{{Name: types.StringValue("service")}},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			m := tt.in
+			client := &notificationGroupCreatorTester{ID: tt.inID}
+			if err := m.createInner(ctx, client); err != nil {
+				t.Errorf("unexpected error: %+v", err)
+				return
+			}
+
+			if diff := cmp.Diff(client.Request, tt.wantReq); diff != "" {
+				t.Errorf("invalid request:\n%s", diff)
+			}
+			if diff := cmp.Diff(m, tt.wants); diff != "" {
+				t.Errorf("invalid model:\n%s", diff)
+			}
+		})
+	}
+}
+
+type notificationGroupCreatorTester struct {
+	ID string
+
+	Request mackerel.NotificationGroup
+}
+
+func (ct *notificationGroupCreatorTester) CreateNotificationGroup(param *mackerel.NotificationGroup) (*mackerel.NotificationGroup, error) {
+	ct.Request = *param
+	data := *param
+	data.ID = ct.ID
+	return &data, nil
+}

--- a/internal/provider/data_source_mackerel_notification_group.go
+++ b/internal/provider/data_source_mackerel_notification_group.go
@@ -1,0 +1,103 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel"
+)
+
+var (
+	_ datasource.DataSource              = (*mackerelNotificationGroupDataSource)(nil)
+	_ datasource.DataSourceWithConfigure = (*mackerelNotificationGroupDataSource)(nil)
+)
+
+func NewMackerelNotificationGroupDataSource() datasource.DataSource {
+	return &mackerelNotificationGroupDataSource{}
+}
+
+type mackerelNotificationGroupDataSource struct {
+	Client *mackerel.Client
+}
+
+func (d *mackerelNotificationGroupDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_notification_group"
+}
+
+func (d *mackerelNotificationGroupDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Required: true,
+			},
+			"name": schema.StringAttribute{
+				Computed: true,
+			},
+			"notification_level": schema.StringAttribute{
+				Computed: true,
+			},
+			"child_notification_group_ids": schema.SetAttribute{
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+			"child_channel_ids": schema.SetAttribute{
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+		},
+		// TODO: migrate to nested attributes (terraform plugin protocol v6 is required)
+		Blocks: map[string]schema.Block{
+			"monitor": schema.SetNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Computed: true,
+						},
+						"skip_default": schema.BoolAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+			"service": schema.SetNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *mackerelNotificationGroupDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	client, diags := retrieveClient(ctx, req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+	d.Client = client
+}
+
+func (d *mackerelNotificationGroupDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config mackerel.NotificationGroupModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data, err := mackerel.ReadNotificationGroup(ctx, d.Client, config.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to read Notification Group.",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/data_source_mackerel_notification_group.go
+++ b/internal/provider/data_source_mackerel_notification_group.go
@@ -28,21 +28,33 @@ func (d *mackerelNotificationGroupDataSource) Metadata(_ context.Context, req da
 
 func (d *mackerelNotificationGroupDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Description: "This data source allows access to details of a specific notitication group setting.",
+
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
+				Description: "The ID of the notitication group",
+
 				Required: true,
 			},
 			"name": schema.StringAttribute{
+				Description: "The name of the notification group",
+
 				Computed: true,
 			},
 			"notification_level": schema.StringAttribute{
+				MarkdownDescription: "The level of notitication (`all` or `critical`)",
+
 				Computed: true,
 			},
 			"child_notification_group_ids": schema.SetAttribute{
+				Description: "A set of notification group IDs",
+
 				ElementType: types.StringType,
 				Computed:    true,
 			},
 			"child_channel_ids": schema.SetAttribute{
+				Description: "A set of notification channel IDs",
+
 				ElementType: types.StringType,
 				Computed:    true,
 			},
@@ -50,21 +62,31 @@ func (d *mackerelNotificationGroupDataSource) Schema(_ context.Context, _ dataso
 		// TODO: migrate to nested attributes (terraform plugin protocol v6 is required)
 		Blocks: map[string]schema.Block{
 			"monitor": schema.SetNestedBlock{
+				Description: "A set of notification target monitor rules",
+
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
+							Description: "The monitor rule ID",
+
 							Computed: true,
 						},
 						"skip_default": schema.BoolAttribute{
+							Description: "If true, send notifications to this notification group only",
+
 							Computed: true,
 						},
 					},
 				},
 			},
 			"service": schema.SetNestedBlock{
+				Description: "A set of notification target services",
+
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"name": schema.StringAttribute{
+							Description: "the name of the service",
+
 							Computed: true,
 						},
 					},

--- a/internal/provider/data_source_mackerel_notification_group_test.go
+++ b/internal/provider/data_source_mackerel_notification_group_test.go
@@ -1,0 +1,26 @@
+package provider_test
+
+import (
+	"context"
+	"testing"
+
+	fwdatasource "github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider"
+)
+
+func Test_MackerelNotificationGroupDataSource_schema(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	req := fwdatasource.SchemaRequest{}
+	resp := &fwdatasource.SchemaResponse{}
+	provider.NewMackerelNotificationGroupDataSource().Schema(ctx, req, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema method diagnostics: %+v", resp.Diagnostics)
+	}
+
+	if diags := resp.Schema.ValidateImplementation(ctx); diags.HasError() {
+		t.Fatalf("schema validation diagnostics: %+v", diags)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -83,6 +83,7 @@ func (m *mackerelProvider) Configure(ctx context.Context, req provider.Configure
 
 func (m *mackerelProvider) Resources(context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
+		NewMackerelNotificationGroupResource,
 		NewMackerelServiceResource,
 		NewMackerelServiceMetadataResource,
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -90,9 +90,10 @@ func (m *mackerelProvider) Resources(context.Context) []func() resource.Resource
 
 func (m *mackerelProvider) DataSources(context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
+		NewMackerelNotificationGroupDataSource,
 		NewMackerelServiceDataSource,
-		NewMackerelServiceMetricNamesDataSource,
 		NewMackerelServiceMetadataDataSource,
+		NewMackerelServiceMetricNamesDataSource,
 	}
 }
 

--- a/internal/provider/resource_mackerel_notification_group.go
+++ b/internal/provider/resource_mackerel_notification_group.go
@@ -1,0 +1,202 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel"
+)
+
+var (
+	_ resource.Resource                = (*mackerelNotificationGroupResource)(nil)
+	_ resource.ResourceWithConfigure   = (*mackerelNotificationGroupResource)(nil)
+	_ resource.ResourceWithImportState = (*mackerelNotificationGroupResource)(nil)
+)
+
+func NewMackerelNotificationGroupResource() resource.Resource {
+	return &mackerelNotificationGroupResource{}
+}
+
+type mackerelNotificationGroupResource struct {
+	Client *mackerel.Client
+}
+
+func (r *mackerelNotificationGroupResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_notification_group"
+}
+
+func (r *mackerelNotificationGroupResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "This resource allows creating and management of notification groups",
+
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "The ID of the notitication group",
+
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Description: "The name of the notification group",
+
+				Required: true,
+			},
+			"notification_level": schema.StringAttribute{
+				MarkdownDescription: "The level of notitication (`all` or `critical`)",
+
+				Optional: true,
+				Computed: true,
+				Validators: []validator.String{
+					mackerel.NotificationLevelValidator(),
+				},
+				Default: stringdefault.StaticString("all"),
+			},
+			"child_notification_group_ids": schema.SetAttribute{
+				Description: "A set of notification group IDs",
+
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			"child_channel_ids": schema.SetAttribute{
+				Description: "A set of notification channel IDs",
+
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+		},
+		// TODO: migrate to nested attributes
+		Blocks: map[string]schema.Block{
+			"monitor": schema.SetNestedBlock{
+				Description: "Configuration block(s) with monitor rules",
+
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Description: "The monitor rule ID",
+
+							Required: true,
+						},
+						"skip_default": schema.BoolAttribute{
+							Description: "If true, send notifications to this notification group only.",
+
+							Optional: true,
+							Computed: true,
+							Default:  booldefault.StaticBool(false),
+						},
+					},
+				},
+			},
+			"service": schema.SetNestedBlock{
+				Description: "Configuration block(s) with services",
+
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Description: "The name of the service",
+
+							Required: true,
+							Validators: []validator.String{
+								mackerel.ServiceNameValidator(),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *mackerelNotificationGroupResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	client, diags := retrieveClient(ctx, req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+	r.Client = client
+}
+
+func (r *mackerelNotificationGroupResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data mackerel.NotificationGroupModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Create(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to create Notification Group",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *mackerelNotificationGroupResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data mackerel.NotificationGroupModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Read(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable read Notification Group",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *mackerelNotificationGroupResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data mackerel.NotificationGroupModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Update(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to update Notification Group",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *mackerelNotificationGroupResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data mackerel.NotificationGroupModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Delete(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to delete Notification Group",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *mackerelNotificationGroupResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/provider/resource_mackerel_notification_group_test.go
+++ b/internal/provider/resource_mackerel_notification_group_test.go
@@ -1,0 +1,26 @@
+package provider_test
+
+import (
+	"context"
+	"testing"
+
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider"
+)
+
+func Test_MackerelNotificationGroupResource_schema(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	req := fwresource.SchemaRequest{}
+	resp := &fwresource.SchemaResponse{}
+	provider.NewMackerelNotificationGroupResource().Schema(ctx, req, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema method diagnotstics: %+v", resp.Diagnostics)
+	}
+
+	if diags := resp.Schema.ValidateImplementation(ctx); diags.HasError() {
+		t.Fatalf("schema validation diagnotstics: %+v", diags)
+	}
+}

--- a/mackerel/provider.go
+++ b/mackerel/provider.go
@@ -86,6 +86,7 @@ func protoV5ProviderServer(provider *schema.Provider) tfprotov5.ProviderServer {
 		delete(provider.ResourcesMap, "mackerel_service_metadata")
 
 		// Data Sources
+		delete(provider.DataSourcesMap, "mackerel_notification_group")
 		delete(provider.DataSourcesMap, "mackerel_service")
 		delete(provider.DataSourcesMap, "mackerel_service_metric_names")
 		delete(provider.DataSourcesMap, "mackerel_service_metadata")

--- a/mackerel/provider.go
+++ b/mackerel/provider.go
@@ -82,14 +82,15 @@ func protoV5ProviderServer(provider *schema.Provider) tfprotov5.ProviderServer {
 		log.Printf("[INFO] mackerel: use terraform-plugin-framework based implementation")
 
 		// Resources
+		delete(provider.ResourcesMap, "mackerel_notification_group")
 		delete(provider.ResourcesMap, "mackerel_service")
 		delete(provider.ResourcesMap, "mackerel_service_metadata")
 
 		// Data Sources
 		delete(provider.DataSourcesMap, "mackerel_notification_group")
 		delete(provider.DataSourcesMap, "mackerel_service")
-		delete(provider.DataSourcesMap, "mackerel_service_metric_names")
 		delete(provider.DataSourcesMap, "mackerel_service_metadata")
+		delete(provider.DataSourcesMap, "mackerel_service_metric_names")
 
 		mux, err := tf5muxserver.NewMuxServer(
 			context.Background(),


### PR DESCRIPTION
Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ MACKEREL_EXPERIMENTAL_TFFRAMEWORK=1 make testacc TESTS='"TestAcc(DataSource)?MackerelNotificationGroup"'
TF_ACC=1 go test -v ./mackerel/... -run "TestAcc(DataSource)?MackerelNotificationGroup" -timeout 120m
2024/07/03 20:27:09 [INFO] mackerel: use terraform-plugin-framework based implementation
=== RUN   TestAccDataSourceMackerelNotificationGroup
=== PAUSE TestAccDataSourceMackerelNotificationGroup
=== RUN   TestAccMackerelNotificationGroup
=== PAUSE TestAccMackerelNotificationGroup
=== CONT  TestAccDataSourceMackerelNotificationGroup
=== CONT  TestAccMackerelNotificationGroup
--- PASS: TestAccDataSourceMackerelNotificationGroup (6.15s)
--- PASS: TestAccMackerelNotificationGroup (10.66s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel 12.024s
```
