### PR TITLE
Adds framework based acctest for "mackerel_service"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test:
 
 .PHONY: testacc
 testacc:
-	TF_ACC=1 go test -v ./mackerel/... -run $(TESTS) -timeout 120m
+	TF_ACC=1 go test -v ./mackerel/... ./internal/provider/... -run $(TESTS) -timeout 120m
 
 .PHONY: local-build
 local-build:

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,14 @@ go 1.22.0
 require (
 	github.com/golangci/golangci-lint v1.50.1
 	github.com/google/go-cmp v0.6.0
+	github.com/hashicorp/terraform-json v0.22.1
 	github.com/hashicorp/terraform-plugin-framework v1.8.0
 	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.1.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-mux v0.16.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
+	github.com/hashicorp/terraform-plugin-testing v1.8.0
 	github.com/mackerelio/mackerel-client-go v0.33.0
 )
 
@@ -83,7 +85,7 @@ require (
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
-	github.com/hashicorp/go-hclog v1.5.0 // indirect
+	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.6.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
@@ -93,7 +95,6 @@ require (
 	github.com/hashicorp/hcl/v2 v2.20.1 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.21.0 // indirect
-	github.com/hashicorp/terraform-json v0.22.1 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -314,8 +314,8 @@ github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9n
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 h1:1/D3zfFHttUKaCaGKZ/dR2roBXv0vKbSCnssIldfQdI=
 github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320/go.mod h1:EiZBMaudVLy8fmjf9Npq1dq9RalhveqZG5w/yz3mHWs=
-github.com/hashicorp/go-hclog v1.5.0 h1:bI2ocEMgcVlz55Oj1xZNBsVi900c7II+fWDyV9o+13c=
-github.com/hashicorp/go-hclog v1.5.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
+github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=
+github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.6.0 h1:wgd4KxHJTVGGqWBq4QPB1i5BZNEx9BR8+OFmHDmTk8A=
@@ -354,6 +354,8 @@ github.com/hashicorp/terraform-plugin-mux v0.16.0 h1:RCzXHGDYwUwwqfYYWJKBFaS3fQs
 github.com/hashicorp/terraform-plugin-mux v0.16.0/go.mod h1:PF79mAsPc8CpusXPfEVa4X8PtkB+ngWoiUClMrNZlYo=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0 h1:kJiWGx2kiQVo97Y5IOGR4EMcZ8DtMswHhUuFibsCQQE=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0/go.mod h1:sl/UoabMc37HA6ICVMmGO+/0wofkVIRxf+BMb/dnoIg=
+github.com/hashicorp/terraform-plugin-testing v1.8.0 h1:wdYIgwDk4iO933gC4S8KbKdnMQShu6BXuZQPScmHvpk=
+github.com/hashicorp/terraform-plugin-testing v1.8.0/go.mod h1:o2kOgf18ADUaZGhtOl0YCkfIxg01MAiMATT2EtIHlZk=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=

--- a/internal/provider/data_source_mackerel_service_test.go
+++ b/internal/provider/data_source_mackerel_service_test.go
@@ -2,13 +2,19 @@ package provider_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	fwdatasource "github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider"
 )
 
-func TestMackerelServiceDataSourceSchema(t *testing.T) {
+func Test_MackerelServiceDataSource_schema(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -23,4 +29,41 @@ func TestMackerelServiceDataSourceSchema(t *testing.T) {
 	if diags := resp.Schema.ValidateImplementation(ctx); diags.HasError() {
 		t.Fatalf("schema validation diagnostics: %+v", diags)
 	}
+}
+
+func TestAcc_MackerelServiceDataSource_basic(t *testing.T) {
+	name := fmt.Sprintf("tf-service-%s", acctest.RandString(5))
+	resourceName := "data.mackerel_service.foo"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: mackerelServiceDataSourceConfig(name),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(name)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(name)),
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("memo"),
+						knownvalue.StringExact("This service is managed by Terraform."),
+					),
+				},
+			},
+		},
+	})
+}
+
+func mackerelServiceDataSourceConfig(name string) string {
+	return fmt.Sprintf(`
+resource "mackerel_service" "foo" {
+  name = "%s"
+  memo = "This service is managed by Terraform."
+}
+
+data "mackerel_service" "foo" {
+  name = mackerel_service.foo.id
+}
+`, name)
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -2,9 +2,16 @@ package provider_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 
+	tfjson "github.com/hashicorp/terraform-json"
 	fwprovider "github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel"
 	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider"
 )
 
@@ -23,4 +30,58 @@ func TestMackerelProvider_schema(t *testing.T) {
 	if diags := resp.Schema.ValidateImplementation(ctx); diags.HasError() {
 		t.Fatalf("Schema validation: %+v", diags)
 	}
+}
+
+// For acceptance tests
+
+func protoV5ProviderFactories() map[string]func() (tfprotov5.ProviderServer, error) {
+	return map[string]func() (tfprotov5.ProviderServer, error){
+		"mackerel": providerserver.NewProtocol5WithError(provider.New()),
+	}
+}
+
+func preCheck(t *testing.T) {
+	t.Helper()
+
+	// Currently, do nothing
+}
+
+func newClient(t testing.TB) *mackerel.Client {
+	t.Helper()
+
+	config := mackerel.NewClientConfigFromEnv()
+	client, err := config.NewClient()
+	if err != nil {
+		if errors.Is(err, mackerel.ErrNoAPIKey) {
+			t.Fatal("MACKEREL_API_KEY or MACKEREL_APIKEY is required for acceptance tests.")
+		} else {
+			t.Fatalf("Failed to create Mackerel client: %+v", err)
+		}
+	}
+	return client
+}
+
+// state check helpers
+type stateCheckFunc func(ctx context.Context, req statecheck.CheckStateRequest, resp *statecheck.CheckStateResponse)
+
+func (sc stateCheckFunc) CheckState(ctx context.Context, req statecheck.CheckStateRequest, resp *statecheck.CheckStateResponse) {
+	sc(ctx, req, resp)
+}
+
+func findStateResource(state *tfjson.State, resoruceAddress string) (*tfjson.StateResource, error) {
+	if state == nil {
+		return nil, fmt.Errorf("state is nil")
+	}
+	if state.Values == nil {
+		return nil, fmt.Errorf("state does not contain any state values")
+	}
+	if state.Values.RootModule == nil {
+		return nil, fmt.Errorf("state does not contain a root module")
+	}
+	for _, r := range state.Values.RootModule.Resources {
+		if r.Address == resoruceAddress {
+			return r, nil
+		}
+	}
+	return nil, fmt.Errorf("%s - Resource not found in state", resoruceAddress)
 }

--- a/internal/provider/resource_mackerel_service_test.go
+++ b/internal/provider/resource_mackerel_service_test.go
@@ -2,13 +2,25 @@ package provider_test
 
 import (
 	"context"
+	"fmt"
+	"slices"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider"
+	"github.com/mackerelio/mackerel-client-go"
 )
 
-func TestMackerelServiceResourceSchema(t *testing.T) {
+func Test_MackerelServiceResource_schema(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -23,4 +35,146 @@ func TestMackerelServiceResourceSchema(t *testing.T) {
 	if diag := resp.Schema.ValidateImplementation(ctx); diag.HasError() {
 		t.Fatalf("schema validation diagnostics: %+v", diag)
 	}
+}
+
+func TestAcc_MackerelServiceResource_basic(t *testing.T) {
+	client := newClient(t)
+	resourceName := "mackerel_service.foo"
+	name := acctest.RandomWithPrefix("tf")
+	nameUpdated := acctest.RandomWithPrefix("tf-updated")
+	memoUpdated := fmt.Sprintf("%s is managed by Terraform.", nameUpdated)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		CheckDestroy:             checkMackerelServiceDestroy(client),
+		Steps: []resource.TestStep{
+			// Create
+			{
+				Config: mackerelServiceResourceConfig_basic(name),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("id")),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(name)),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("memo"), knownvalue.Null()),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					expectMackerelService(client, resourceName, mackerel.Service{
+						Name: name,
+						Memo: "",
+					}),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(name)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(name)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memo"), knownvalue.Null()),
+				},
+			},
+			// Update
+			{
+				Config: mackerelServiceResourceConfig_withMemo(nameUpdated, memoUpdated),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("id")),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(nameUpdated)),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("memo"), knownvalue.StringExact(memoUpdated)),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					expectMackerelService(client, resourceName, mackerel.Service{
+						Name: nameUpdated,
+						Memo: memoUpdated,
+					}),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(nameUpdated)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(nameUpdated)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memo"), knownvalue.StringExact(memoUpdated)),
+				},
+			},
+			// Import
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func mackerelServiceResourceConfig_basic(name string) string {
+	return fmt.Sprintf(`
+resource "mackerel_service" "foo" {
+  name = "%s"
+}`, name)
+}
+
+func mackerelServiceResourceConfig_withMemo(name string, memo string) string {
+	return fmt.Sprintf(`
+resource "mackerel_service" "foo" {
+  name = "%s"
+  memo = %q
+}`, name, memo)
+}
+
+func checkMackerelServiceDestroy(client *mackerel.Client) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		services, err := client.FindServices()
+		if err != nil {
+			return err
+		}
+		for _, r := range s.RootModule().Resources {
+			if r.Type != "mackerel_service" {
+				continue
+			}
+			if slices.ContainsFunc(services, func(svc *mackerel.Service) bool {
+				return svc.Name == r.Primary.ID
+			}) {
+				return fmt.Errorf("service still exists: %s", r.Primary.ID)
+			}
+		}
+		return nil
+	}
+}
+
+func expectMackerelService(client *mackerel.Client, resourceAddr string, wants mackerel.Service) statecheck.StateCheck {
+	return stateCheckFunc(func(ctx context.Context, req statecheck.CheckStateRequest, resp *statecheck.CheckStateResponse) {
+		resource, err := findStateResource(req.State, resourceAddr)
+		if err != nil {
+			resp.Error = err
+			return
+		}
+		idAny, err := tfjsonpath.Traverse(resource.AttributeValues, tfjsonpath.New("id"))
+		if err != nil {
+			resp.Error = err
+			return
+		}
+		id, ok := idAny.(string)
+		if !ok {
+			resp.Error = fmt.Errorf("id must be a string")
+			return
+		}
+
+		services, err := client.FindServices()
+		if err != nil {
+			resp.Error = err
+			return
+		}
+
+		serviceIdx := slices.IndexFunc(services, func(svc *mackerel.Service) bool {
+			return svc.Name == id
+		})
+		if serviceIdx < 0 {
+			resp.Error = fmt.Errorf("service not found from mackerel: %s", id)
+			return
+		}
+
+		if diff := cmp.Diff(
+			*services[serviceIdx],
+			wants,
+			cmpopts.IgnoreFields(mackerel.Service{}, "Roles"),
+		); diff != "" {
+			resp.Error = fmt.Errorf("unexpected service. diff: %s", diff)
+			return
+		}
+	})
 }


### PR DESCRIPTION
Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS='"TestAcc_MackerelService(Resource|DataSource)_"'
TF_ACC=1 go test -v ./mackerel/... ./internal/provider/... -run "TestAcc_MackerelService(Resource|DataSource)_" -timeout 120m
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel (cached) [no tests to run]
=== RUN   TestAcc_MackerelServiceDataSource_basic
=== PAUSE TestAcc_MackerelServiceDataSource_basic
=== RUN   TestAcc_MackerelServiceResource_basic
=== PAUSE TestAcc_MackerelServiceResource_basic
=== CONT  TestAcc_MackerelServiceDataSource_basic
=== CONT  TestAcc_MackerelServiceResource_basic
--- PASS: TestAcc_MackerelServiceDataSource_basic (4.37s)
--- PASS: TestAcc_MackerelServiceResource_basic (8.32s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider  9.129s
```
