### PR TITLE
Reimplement role metadata with tf-framework

### DIFF
--- a/internal/mackerel/role_metadata.go
+++ b/internal/mackerel/role_metadata.go
@@ -1,0 +1,142 @@
+package mackerel
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+type RoleMetadataModel struct {
+	ID           types.String         `tfsdk:"id"`
+	ServiceName  types.String         `tfsdk:"service"`
+	RoleName     types.String         `tfsdk:"role"`
+	Namespace    types.String         `tfsdk:"namespace"`
+	MetadataJSON jsontypes.Normalized `tfsdk:"metadata_json"`
+}
+
+func roleMetadataID(serviceName, roleName, namespace string) string {
+	return fmt.Sprintf("%s:%s/%s", serviceName, roleName, namespace)
+}
+
+func parseRoleMetadataID(id string) (serviceName, roleName, namespace string, err error) {
+	sn, rest, foundColon := strings.Cut(id, ":")
+	rn, ns, foundSlash := strings.Cut(rest, "/")
+	if !foundColon || !foundSlash {
+		return "", "", "", fmt.Errorf("The ID is expected to have `<service>:<role>/<namespace>` format, but got: '%s'.", id)
+	}
+	return sn, rn, ns, nil
+}
+
+func ReadRoleMetadata(ctx context.Context, client *Client, serviceName, roleName, namespace string) (RoleMetadataModel, error) {
+	return readRoleMetadata(client, serviceName, roleName, namespace)
+}
+
+type roleMetadataReader interface {
+	GetRoleMetaData(serviceName, roleName, namespace string) (*mackerel.RoleMetaDataResp, error)
+}
+
+func readRoleMetadata(client roleMetadataReader, serviceName, roleName, namespace string) (RoleMetadataModel, error) {
+	metadataResp, err := client.GetRoleMetaData(serviceName, roleName, namespace)
+	if err != nil {
+		return RoleMetadataModel{}, err
+	}
+
+	metadataJSON, err := json.Marshal(metadataResp.RoleMetaData)
+	if err != nil {
+		return RoleMetadataModel{}, fmt.Errorf("failed to marshal result: %w", err)
+	}
+
+	id := roleMetadataID(serviceName, roleName, namespace)
+	return RoleMetadataModel{
+		ID:           types.StringValue(id),
+		ServiceName:  types.StringValue(serviceName),
+		RoleName:     types.StringValue(roleName),
+		Namespace:    types.StringValue(namespace),
+		MetadataJSON: jsontypes.NewNormalizedValue(string(metadataJSON)),
+	}, nil
+}
+
+func ImportRoleMetadata(id string) (RoleMetadataModel, error) {
+	serviceName, roleName, namespace, err := parseRoleMetadataID(id)
+	if err != nil {
+		return RoleMetadataModel{}, err
+	}
+	return RoleMetadataModel{
+		ID:          types.StringValue(id),
+		ServiceName: types.StringValue(serviceName),
+		RoleName:    types.StringValue(roleName),
+		Namespace:   types.StringValue(namespace),
+	}, nil
+}
+
+func (m *RoleMetadataModel) Create(ctx context.Context, client *Client) error {
+	return m.create(client)
+}
+
+func (m *RoleMetadataModel) create(client roleMetadataUpdator) error {
+	if err := m.update(client); err != nil {
+		return err
+	}
+
+	m.ID = types.StringValue(
+		roleMetadataID(m.ServiceName.ValueString(), m.RoleName.ValueString(), m.Namespace.ValueString()),
+	)
+
+	return nil
+}
+
+func (m *RoleMetadataModel) Read(ctx context.Context, client *Client) error {
+	data, err := readRoleMetadata(
+		client,
+		m.ServiceName.ValueString(),
+		m.RoleName.ValueString(),
+		m.Namespace.ValueString(),
+	)
+	if err != nil {
+		return err
+	}
+
+	m.ID = data.ID // computed
+	m.MetadataJSON = data.MetadataJSON
+	return nil
+}
+
+func (m RoleMetadataModel) Update(ctx context.Context, client *Client) error {
+	return m.update(client)
+}
+
+type roleMetadataUpdator interface {
+	PutRoleMetaData(serviceName, roleName, namespace string, metadata mackerel.RoleMetaData) error
+}
+
+func (m *RoleMetadataModel) update(client roleMetadataUpdator) error {
+	var metadata mackerel.RoleMetaData
+	if err := json.Unmarshal([]byte(m.MetadataJSON.ValueString()), &metadata); err != nil {
+		return fmt.Errorf("failed to unmarshal metadata: %w", err)
+	}
+	if err := client.PutRoleMetaData(
+		m.ServiceName.ValueString(),
+		m.RoleName.ValueString(),
+		m.Namespace.ValueString(),
+		metadata,
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m RoleMetadataModel) Delete(_ context.Context, client *Client) error {
+	if err := client.DeleteRoleMetaData(
+		m.ServiceName.ValueString(),
+		m.RoleName.ValueString(),
+		m.Namespace.ValueString(),
+	); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/mackerel/role_metadata_test.go
+++ b/internal/mackerel/role_metadata_test.go
@@ -1,0 +1,181 @@
+package mackerel
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+func Test_ReadRoleMetadata(t *testing.T) {
+	t.Parallel()
+
+	defaultClient := func(serviceName, roleName, namespace string) (*mackerel.RoleMetaDataResp, error) {
+		if serviceName != "service" || roleName != "role" || namespace != "namespace" {
+			return nil, fmt.Errorf("no metadata found")
+		}
+		return &mackerel.RoleMetaDataResp{
+			RoleMetaData: map[string]any{"v": 1},
+		}, nil
+	}
+
+	cases := map[string]struct {
+		inClient      roleMetadataReaderFunc
+		inServiceName string
+		inRoleName    string
+		inNamespace   string
+
+		wants RoleMetadataModel
+	}{
+		"basic": {
+			inClient:      defaultClient,
+			inServiceName: "service",
+			inRoleName:    "role",
+			inNamespace:   "namespace",
+
+			wants: RoleMetadataModel{
+				ID:           types.StringValue("service:role/namespace"),
+				ServiceName:  types.StringValue("service"),
+				RoleName:     types.StringValue("role"),
+				Namespace:    types.StringValue("namespace"),
+				MetadataJSON: jsontypes.NewNormalizedValue(`{"v":1}`),
+			},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			data, err := readRoleMetadata(tt.inClient, tt.inServiceName, tt.inRoleName, tt.inNamespace)
+			if err != nil {
+				t.Errorf("unexpected error: %+v", err)
+				return
+			}
+
+			if diff := cmp.Diff(data, tt.wants); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func Test_ImportRoleMetadata(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		inID string
+
+		wants   RoleMetadataModel
+		wantErr bool
+	}{
+		"valid": {
+			inID: "service:role/namespace",
+
+			wants: RoleMetadataModel{
+				ID:          types.StringValue("service:role/namespace"),
+				ServiceName: types.StringValue("service"),
+				RoleName:    types.StringValue("role"),
+				Namespace:   types.StringValue("namespace"),
+			},
+		},
+		"invalid": {
+			inID: "invalidid",
+
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			data, err := ImportRoleMetadata(tt.inID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("unexpected error: %+v", err)
+			}
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(data, tt.wants); diff != "" {
+				t.Error(diff)
+			}
+		})
+
+	}
+}
+
+func Test_RoleMetadata_Create(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		in       RoleMetadataModel
+		inClient roleMetadataUpdatorFunc
+
+		wants RoleMetadataModel
+	}{
+		"basic": {
+			in: RoleMetadataModel{
+				ServiceName:  types.StringValue("service"),
+				RoleName:     types.StringValue("role"),
+				Namespace:    types.StringValue("namespace"),
+				MetadataJSON: jsontypes.NewNormalizedValue(`{"v":1}`),
+			},
+			inClient: func(serviceName, roleName, namespace string, metadata mackerel.RoleMetaData) error {
+				if serviceName != "service" {
+					return fmt.Errorf("unexpected service name: %s", serviceName)
+				}
+				if roleName != "role" {
+					return fmt.Errorf("unexpected role name: %s", roleName)
+				}
+				if namespace != "namespace" {
+					return fmt.Errorf("unexpected namespace: %s", namespace)
+				}
+				if diff := cmp.Diff(metadata, map[string]any{"v": 1.}); diff != "" {
+					return fmt.Errorf("unexpected metadata: %s", diff)
+				}
+				return nil
+			},
+
+			wants: RoleMetadataModel{
+				ID:           types.StringValue("service:role/namespace"),
+				ServiceName:  types.StringValue("service"),
+				RoleName:     types.StringValue("role"),
+				Namespace:    types.StringValue("namespace"),
+				MetadataJSON: jsontypes.NewNormalizedValue(`{"v":1}`),
+			},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			data := tt.in
+			if err := data.create(tt.inClient); err != nil {
+				t.Errorf("unexpected error: %+v", err)
+				return
+			}
+
+			if diff := cmp.Diff(data, tt.wants); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+type roleMetadataReaderFunc func(serviceName, roleName, namespace string) (*mackerel.RoleMetaDataResp, error)
+
+func (f roleMetadataReaderFunc) GetRoleMetaData(serviceName, roleName, namespace string) (*mackerel.RoleMetaDataResp, error) {
+	return f(serviceName, roleName, namespace)
+}
+
+type roleMetadataUpdatorFunc func(serviceName, roleName, namespace string, metadata mackerel.RoleMetaData) error
+
+func (f roleMetadataUpdatorFunc) PutRoleMetaData(serviceName, roleName, namespace string, metadata mackerel.RoleMetaData) error {
+	return f(serviceName, roleName, namespace, metadata)
+}

--- a/internal/provider/data_source_mackerel_role_metadata.go
+++ b/internal/provider/data_source_mackerel_role_metadata.go
@@ -1,0 +1,89 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel"
+)
+
+var (
+	_ datasource.DataSourceWithConfigure = (*mackerelRoleMetadataDataSource)(nil)
+)
+
+func NewMackerelRoleMetadataDataSource() datasource.DataSource {
+	return &mackerelRoleMetadataDataSource{}
+}
+
+type mackerelRoleMetadataDataSource struct {
+	Client *mackerel.Client
+}
+
+func (d *mackerelRoleMetadataDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_role_metadata"
+}
+
+func (d *mackerelRoleMetadataDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "This data source accesses to details of a specific Role Metadata.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"service": schema.StringAttribute{
+				Description: "The name of the service.",
+				Required:    true,
+				Validators:  []validator.String{mackerel.ServiceNameValidator()},
+			},
+			"role": schema.StringAttribute{
+				Description: "The name of the role.",
+				Required:    true,
+				Validators:  []validator.String{mackerel.RoleNameValidator()},
+			},
+			"namespace": schema.StringAttribute{
+				Description: "The identifier for the metadata.",
+				Required:    true,
+			},
+			"metadata_json": schema.StringAttribute{
+				Description: "The arbitrary JSON data for the role.",
+				Computed:    true,
+				CustomType:  jsontypes.NormalizedType{},
+			},
+		},
+	}
+}
+
+func (d *mackerelRoleMetadataDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	client, diags := retrieveClient(ctx, req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+	d.Client = client
+}
+
+func (d *mackerelRoleMetadataDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config mackerel.RoleMetadataModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	serviceName := config.ServiceName.ValueString()
+	roleName := config.RoleName.ValueString()
+	namespace := config.Namespace.ValueString()
+	data, err := mackerel.ReadRoleMetadata(ctx, d.Client, serviceName, roleName, namespace)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Unable to read Role Metadata: service=%s role=%s namespace=%s", serviceName, roleName, namespace),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/data_source_mackerel_role_metadata_test.go
+++ b/internal/provider/data_source_mackerel_role_metadata_test.go
@@ -1,0 +1,25 @@
+package provider_test
+
+import (
+	"context"
+	"testing"
+
+	fwdatasource "github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider"
+)
+
+func Test_MackerelRoleMetadataDataSource_schema(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	req := fwdatasource.SchemaRequest{}
+	resp := fwdatasource.SchemaResponse{}
+	provider.NewMackerelRoleMetadataDataSource().Schema(ctx, req, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %+v", resp.Diagnostics)
+	}
+
+	if diags := resp.Schema.ValidateImplementation(ctx); diags.HasError() {
+		t.Fatalf("schema validation diagnostics: %+v", diags)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -85,6 +85,7 @@ func (m *mackerelProvider) Resources(context.Context) []func() resource.Resource
 	return []func() resource.Resource{
 		NewMackerelNotificationGroupResource,
 		NewMackerelRoleResource,
+		NewMackerelRoleMetadataResource,
 		NewMackerelServiceResource,
 		NewMackerelServiceMetadataResource,
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -94,6 +94,7 @@ func (m *mackerelProvider) DataSources(context.Context) []func() datasource.Data
 	return []func() datasource.DataSource{
 		NewMackerelNotificationGroupDataSource,
 		NewMackerelRoleDataSource,
+		NewMackerelRoleMetadataDataSource,
 		NewMackerelServiceDataSource,
 		NewMackerelServiceMetadataDataSource,
 		NewMackerelServiceMetricNamesDataSource,

--- a/internal/provider/resource_mackerel_role_metadata.go
+++ b/internal/provider/resource_mackerel_role_metadata.go
@@ -1,0 +1,171 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel"
+)
+
+var (
+	_ resource.Resource                = (*mackerelRoleMetadataResource)(nil)
+	_ resource.ResourceWithConfigure   = (*mackerelRoleMetadataResource)(nil)
+	_ resource.ResourceWithImportState = (*mackerelRoleMetadataResource)(nil)
+)
+
+func NewMackerelRoleMetadataResource() resource.Resource {
+	return &mackerelRoleMetadataResource{}
+}
+
+type mackerelRoleMetadataResource struct {
+	Client *mackerel.Client
+}
+
+func (r *mackerelRoleMetadataResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_role_metadata"
+}
+
+func (r *mackerelRoleMetadataResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "This resource creates and manages a Role Metadata.",
+
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(), // immutable
+				},
+			},
+			"service": schema.StringAttribute{
+				Description: "The name of the service.",
+				Required:    true,
+				Validators: []validator.String{
+					mackerel.ServiceNameValidator(),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(), // force new
+				},
+			},
+			"role": schema.StringAttribute{
+				Description: "The name of the role.",
+				Required:    true,
+				Validators: []validator.String{
+					mackerel.RoleNameValidator(),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(), // force new
+				},
+			},
+			"namespace": schema.StringAttribute{
+				Description: "The identifier for the metadata.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(), // force new
+				},
+			},
+			"metadata_json": schema.StringAttribute{
+				Description: "The arbitrary JSON data for the role.",
+				Required:    true,
+				CustomType:  jsontypes.NormalizedType{},
+			},
+		},
+	}
+}
+
+func (r *mackerelRoleMetadataResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	client, diags := retrieveClient(ctx, req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+	r.Client = client
+}
+
+func (r *mackerelRoleMetadataResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data mackerel.RoleMetadataModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Create(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to create Role Metadata",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *mackerelRoleMetadataResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data mackerel.RoleMetadataModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Read(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to read Role Metadata",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *mackerelRoleMetadataResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data mackerel.RoleMetadataModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Update(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to update Role Metadata",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *mackerelRoleMetadataResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data mackerel.RoleMetadataModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Delete(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to delete Role Metadata",
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *mackerelRoleMetadataResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	data, err := mackerel.ImportRoleMetadata(req.ID)
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("id"),
+			"Invalid ID",
+			err.Error(),
+		)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/resource_mackerel_role_metadata_test.go
+++ b/internal/provider/resource_mackerel_role_metadata_test.go
@@ -1,0 +1,25 @@
+package provider_test
+
+import (
+	"context"
+	"testing"
+
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider"
+)
+
+func Test_MackerelRoleMetadataResource_schema(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	req := fwresource.SchemaRequest{}
+	resp := fwresource.SchemaResponse{}
+	provider.NewMackerelRoleMetadataResource().Schema(ctx, req, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %+v", resp.Diagnostics)
+	}
+
+	if diags := resp.Schema.ValidateImplementation(ctx); diags.HasError() {
+		t.Fatalf("schema validation diagnostics: %+v", diags)
+	}
+}

--- a/mackerel/data_source_mackerel_role_metadata_test.go
+++ b/mackerel/data_source_mackerel_role_metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestDataSourceMackerelRoleMetadata(t *testing.T) {
+func TestAccDataSourceMackerelRoleMetadata(t *testing.T) {
 	dsName := "data.mackerel_role_metadata.foo"
 	rand := acctest.RandString(5)
 	service := fmt.Sprintf("tf-service-%s", rand)

--- a/mackerel/provider.go
+++ b/mackerel/provider.go
@@ -84,6 +84,7 @@ func protoV5ProviderServer(provider *schema.Provider) tfprotov5.ProviderServer {
 		// Resources
 		delete(provider.ResourcesMap, "mackerel_notification_group")
 		delete(provider.ResourcesMap, "mackerel_role")
+		delete(provider.ResourcesMap, "mackerel_role_metadata")
 		delete(provider.ResourcesMap, "mackerel_service")
 		delete(provider.ResourcesMap, "mackerel_service_metadata")
 

--- a/mackerel/provider.go
+++ b/mackerel/provider.go
@@ -90,6 +90,7 @@ func protoV5ProviderServer(provider *schema.Provider) tfprotov5.ProviderServer {
 		// Data Sources
 		delete(provider.DataSourcesMap, "mackerel_notification_group")
 		delete(provider.DataSourcesMap, "mackerel_role")
+		delete(provider.DataSourcesMap, "mackerel_role_metadata")
 		delete(provider.DataSourcesMap, "mackerel_service")
 		delete(provider.DataSourcesMap, "mackerel_service_metadata")
 		delete(provider.DataSourcesMap, "mackerel_service_metric_names")


### PR DESCRIPTION
Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ MACKEREL_EXPERIMENTAL_TFFRAMEWORK=1 make testacc TESTS='"TestAcc(DataSource)?MackerelRoleMetadata"'
TF_ACC=1 go test -v ./mackerel/... -run "TestAcc(DataSource)?MackerelRoleMetadata" -timeout 120m
2024/08/07 17:16:18 [INFO] mackerel: use terraform-plugin-framework based implementation
=== RUN   TestAccDataSourceMackerelRoleMetadata
=== PAUSE TestAccDataSourceMackerelRoleMetadata
=== RUN   TestAccMackerelRoleMetadata
=== PAUSE TestAccMackerelRoleMetadata
=== CONT  TestAccDataSourceMackerelRoleMetadata
=== CONT  TestAccMackerelRoleMetadata
--- PASS: TestAccDataSourceMackerelRoleMetadata (6.20s)
--- PASS: TestAccMackerelRoleMetadata (11.06s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel 12.943s
```
