### PR TITLE
Add FloatStringType

### DIFF
--- a/internal/typeutil/floatstring.go
+++ b/internal/typeutil/floatstring.go
@@ -1,0 +1,213 @@
+package typeutil
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+type (
+	FloatStringType struct {
+		basetypes.StringType
+	}
+	FloatString struct {
+		basetypes.StringValue
+	}
+)
+
+var (
+	_ basetypes.StringTypable = (*FloatStringType)(nil)
+)
+
+func (t FloatStringType) String() string {
+	return "typeutil.FloatStringType"
+}
+
+func (t FloatStringType) ValueType(ctx context.Context) attr.Value {
+	return FloatString{}
+}
+
+func (t FloatStringType) Equal(o attr.Type) bool {
+	other, ok := o.(FloatStringType)
+	if !ok {
+		return false
+	}
+	return t.StringType.Equal(other.StringType)
+}
+
+func (t FloatStringType) Validate(ctx context.Context, in tftypes.Value, path path.Path) (diags diag.Diagnostics) {
+	if in.Type() == nil {
+		return diags
+	}
+
+	if !in.Type().Is(tftypes.String) {
+		msg := fmt.Sprintf("expected String value, but got %T with value: %v", in, in)
+		diags.AddAttributeError(
+			path,
+			"Float String Type Validation Error",
+			"An unexpected error was encountered trying to validate an attribute value. This is always an error in the provider. "+
+				"Please report the following to the provider developer:\n\n"+msg,
+		)
+		return diags
+	}
+
+	if !in.IsKnown() || in.IsNull() {
+		return diags
+	}
+
+	var valueString string
+	if err := in.As(&valueString); err != nil {
+		diags.AddAttributeError(
+			path,
+			"Float String Type Validation Error",
+			"An unexpected error was encountered trying to validate an attribute value. This is always an error in the provider. "+
+				"Please report the following to the provider developer:\n\n"+err.Error(),
+		)
+		return diags
+	}
+
+	// For legacy reasons, empty strings are treated as a kind of empty value.
+	if valueString == "" {
+		return diags
+	}
+
+	if _, err := strconv.ParseFloat(valueString, 64); err != nil {
+		diags.AddAttributeError(
+			path,
+			"Invalid Float String Value",
+			"A string value was provided that is not valid float string format.\n\n"+
+				"Given value: "+valueString+"\n"+
+				err.Error(),
+		)
+		return diags
+	}
+
+	return diags
+}
+
+func (t FloatStringType) ValueFromString(ctx context.Context, in basetypes.StringValue) (basetypes.StringValuable, diag.Diagnostics) {
+	return FloatString{StringValue: in}, nil
+}
+
+func (t FloatStringType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.StringType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.StringValue)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	return FloatString{StringValue: stringValue}, nil
+}
+
+var (
+	_ basetypes.StringValuable                   = (*FloatString)(nil)
+	_ basetypes.Float64Valuable                  = (*FloatString)(nil)
+	_ basetypes.StringValuableWithSemanticEquals = (*FloatString)(nil)
+)
+
+func NewFloatStringNull() FloatString {
+	return FloatString{StringValue: basetypes.NewStringNull()}
+}
+
+func NewFloatStringUnknown() FloatString {
+	return FloatString{StringValue: basetypes.NewStringUnknown()}
+}
+
+func NewFloatStringValue(value string) FloatString {
+	return FloatString{StringValue: basetypes.NewStringValue(value)}
+}
+
+func NewFloatStringPointerValue(value *string) FloatString {
+	return FloatString{StringValue: basetypes.NewStringPointerValue(value)}
+}
+
+func (v FloatString) Type(_ context.Context) attr.Type {
+	return FloatStringType{}
+}
+
+func (v FloatString) ToFloat64Value(_ context.Context) (basetypes.Float64Value, diag.Diagnostics) {
+	if v.StringValue.IsUnknown() {
+		return basetypes.NewFloat64Unknown(), nil
+	}
+	if v.StringValue.IsNull() {
+		return basetypes.NewFloat64Null(), nil
+	}
+
+	var diags diag.Diagnostics
+	valueString := v.ValueString()
+	f, err := strconv.ParseFloat(valueString, 64)
+	if err != nil {
+		diags.AddError(
+			"Conversion Error",
+			"An unexected string value was received while converting to float value. "+
+				"Please report this to the provider developers.\n\n"+
+				"Got value: "+valueString+"\n"+
+				err.Error(),
+		)
+		return basetypes.Float64Value{}, diags
+	}
+	return basetypes.NewFloat64Value(f), nil
+}
+
+func (v FloatString) ValueFloat64() float64 {
+	fp := v.ValueFloat64Pointer()
+	if fp == nil {
+		return 0.0
+	}
+	return *fp
+}
+
+func (v FloatString) ValueFloat64Pointer() *float64 {
+	if v.StringValue.IsUnknown() || v.StringValue.IsNull() {
+		return nil
+	}
+	f, err := strconv.ParseFloat(v.ValueString(), 64)
+	if err != nil {
+		return nil
+	}
+	return &f
+}
+
+func (v FloatString) Equal(o attr.Value) bool {
+	other, ok := o.(FloatString)
+	if !ok {
+		return false
+	}
+	return v.StringValue.Equal(other.StringValue)
+}
+
+func (v FloatString) StringSemanticEquals(ctx context.Context, otherValuable basetypes.StringValuable) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	otherValue, ok := otherValuable.(FloatString)
+	if !ok {
+		diags.AddError(
+			"Semantic Equality Check Error",
+			"An unexpected value type was received while performing semantic equality checks. "+
+				"Please report this to the provider developers.\n\n"+
+				"Expected: "+fmt.Sprintf("%T", v)+"\n"+
+				"Got: "+fmt.Sprintf("%T", otherValuable),
+		)
+		return false, diags
+	}
+
+	valueFloat, diagConv := v.ToFloat64Value(ctx)
+	diags.Append(diagConv...)
+	otherValueFloat, diagConv := otherValue.ToFloat64Value(ctx)
+	diags.Append(diagConv...)
+	if diags.HasError() {
+		return false, diags
+	}
+
+	return valueFloat.Equal(otherValueFloat), nil
+}

--- a/internal/typeutil/floatstring_test.go
+++ b/internal/typeutil/floatstring_test.go
@@ -1,0 +1,194 @@
+package typeutil_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/typeutil"
+)
+
+func Test_FloatStringType_Validate(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		in      tftypes.Value
+		wantErr bool
+	}{
+		"empty struct": {
+			in: tftypes.Value{},
+		},
+		"null": {
+			in: tftypes.NewValue(tftypes.String, nil),
+		},
+		"unknown": {
+			in: tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+		},
+		"empty string": {
+			in: tftypes.NewValue(tftypes.String, ""),
+		},
+		"valid float string": {
+			in: tftypes.NewValue(tftypes.String, ".1"),
+		},
+		"invalid float string": {
+			in:      tftypes.NewValue(tftypes.String, "xyz"),
+			wantErr: true,
+		},
+		"wrong type": {
+			in:      tftypes.NewValue(tftypes.Number, .1),
+			wantErr: true,
+		},
+	}
+
+	ctx := context.Background()
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := typeutil.FloatStringType{}.Validate(ctx, tt.in, path.Root("test"))
+
+			if diags.HasError() != tt.wantErr {
+				t.Errorf("unexpected diags: %+v", diags)
+			}
+		})
+	}
+}
+
+func Test_FloatStringType_FromTerraform(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		in      tftypes.Value
+		wants   attr.Value
+		wantErr bool
+	}{
+		"value": {
+			in:    tftypes.NewValue(tftypes.String, ".1"),
+			wants: typeutil.NewFloatStringValue(".1"),
+		},
+		"unknown": {
+			in:    tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			wants: typeutil.NewFloatStringUnknown(),
+		},
+		"null": {
+			in:    tftypes.NewValue(tftypes.String, nil),
+			wants: typeutil.NewFloatStringNull(),
+		},
+		"empty string": {
+			in:    tftypes.NewValue(tftypes.String, ""),
+			wants: typeutil.NewFloatStringValue(""),
+		},
+		"wrong type": {
+			in:      tftypes.NewValue(tftypes.Number, .1),
+			wantErr: true,
+		},
+	}
+
+	ctx := context.Background()
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := typeutil.FloatStringType{}.ValueFromTerraform(ctx, tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("unexpected error: %+v", err)
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(got, tt.wants); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func Test_FloatString_StringSemanticEquals(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		in        typeutil.FloatString
+		inOther   basetypes.StringValuable
+		wantMatch bool
+		wantErr   bool
+	}{
+		"strong equal": {
+			in:        typeutil.NewFloatStringValue("0.1"),
+			inOther:   typeutil.NewFloatStringValue("0.1"),
+			wantMatch: true,
+		},
+		"point": {
+			in:        typeutil.NewFloatStringValue("0.1"),
+			inOther:   typeutil.NewFloatStringValue(".1"),
+			wantMatch: true,
+		},
+		"exp": {
+			in:        typeutil.NewFloatStringValue("0.1"),
+			inOther:   typeutil.NewFloatStringValue("1e-1"),
+			wantMatch: true,
+		},
+		"wrong type": {
+			in:      typeutil.NewFloatStringValue("0.1"),
+			inOther: basetypes.NewStringValue("0.1"),
+			wantErr: true,
+		},
+	}
+
+	ctx := context.Background()
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			match, diags := tt.in.StringSemanticEquals(ctx, tt.inOther)
+			if diags.HasError() != tt.wantErr {
+				t.Errorf("unexpected diags: %+v", diags)
+			}
+			if diags.HasError() {
+				return
+			}
+			if match != tt.wantMatch {
+				t.Error("unexpected matching result")
+			}
+		})
+	}
+}
+
+func Test_FloatString_ValueFloat64(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		in    typeutil.FloatString
+		wants float64
+	}{
+		"value": {
+			in:    typeutil.NewFloatStringValue("0.1"),
+			wants: 0.1,
+		},
+		"unknown": {
+			in:    typeutil.NewFloatStringUnknown(),
+			wants: 0.0,
+		},
+		"null": {
+			in:    typeutil.NewFloatStringNull(),
+			wants: 0.0,
+		},
+		"invalid": {
+			in:    typeutil.NewFloatStringValue("invalid"),
+			wants: 0.0,
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if tt.in.ValueFloat64() != tt.wants {
+				t.Error("unmatched")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Part of #233.
Some attributes on monitors uses strings to represent float values. To handle such values, this PR introduces a new [Custom Type](https://developer.hashicorp.com/terraform/plugin/framework/handling-data/types/custom) which stores numbers as strings.
