### PR TITLE
Make the provider schema stable for environment variables

### DIFF
--- a/mackerel/provider.go
+++ b/mackerel/provider.go
@@ -21,7 +21,7 @@ func Provider() *schema.Provider {
 		Schema: map[string]*schema.Schema{
 			"api_key": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
 					"MACKEREL_APIKEY",
 					"MACKEREL_API_KEY",


### PR DESCRIPTION
Fixes: #223

When using `Required` and `DefaultFunc` at the same time, the attribute may become Optional depending on the result returned by `DefaultFunc`([FYI](https://github.com/hashicorp/terraform-plugin-sdk/blob/4c604df5f03572d01e7c32777b339519213eb475/helper/schema/core_schema.go#L140-L152)). This makes the schema unstable.
This PR fixes this behaviour by making `api_key` optional. Validations for `api_key` will be performed at provider initialization time.


Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS='TestAccMackerelService'
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelService -timeout 120m
=== RUN   TestAccMackerelServiceMetadata
=== PAUSE TestAccMackerelServiceMetadata
=== RUN   TestAccMackerelService
=== PAUSE TestAccMackerelService
=== CONT  TestAccMackerelServiceMetadata
=== CONT  TestAccMackerelService
=== RUN   TestAccMackerelService/with_memo
=== PAUSE TestAccMackerelService/with_memo
=== RUN   TestAccMackerelService/no_memo
=== PAUSE TestAccMackerelService/no_memo
=== CONT  TestAccMackerelService/with_memo
=== CONT  TestAccMackerelService/no_memo
--- PASS: TestAccMackerelServiceMetadata (9.68s)
--- PASS: TestAccMackerelService (0.00s)
    --- PASS: TestAccMackerelService/with_memo (9.52s)
    --- PASS: TestAccMackerelService/no_memo (10.10s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel 11.202s
```
