### PR TITLE
Reimplement notification channels with tf-framework

### DIFF
--- a/internal/mackerel/channel.go
+++ b/internal/mackerel/channel.go
@@ -1,0 +1,233 @@
+package mackerel
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+type (
+	ChannelModel struct {
+		ID      types.String          `tfsdk:"id"`
+		Name    types.String          `tfsdk:"name"`
+		Email   []ChannelEmailModel   `tfsdk:"email"`
+		Slack   []ChannelSlackModel   `tfsdk:"slack"`
+		Webhook []ChannelWebhookModel `tfsdk:"webhook"`
+	}
+	ChannelEmailModel struct {
+		Emails  []string `tfsdk:"emails"`
+		UserIDs []string `tfsdk:"user_ids"`
+		Events  []string `tfsdk:"events"`
+	}
+	ChannelSlackModel struct {
+		URL               types.String      `tfsdk:"url"`
+		Mentions          map[string]string `tfsdk:"mentions"`
+		EnabledGraphImage types.Bool        `tfsdk:"enabled_graph_image"`
+		Events            []string          `tfsdk:"events"`
+	}
+	ChannelWebhookModel struct {
+		URL    types.String `tfsdk:"url"`
+		Events []string     `tfsdk:"events"`
+	}
+)
+
+// Reads a channel by the ID.
+// Currently this function is NOT cancelable.
+func ReadChannel(_ context.Context, client *Client, id string) (ChannelModel, error) {
+	channels, err := client.FindChannels()
+	if err != nil {
+		return ChannelModel{}, err
+	}
+
+	channelIdx := slices.IndexFunc(channels, func(c *mackerel.Channel) bool {
+		return c.ID == id
+	})
+	if channelIdx < 0 {
+		return ChannelModel{}, fmt.Errorf("the ID '%s' does not match any channel in mackerel.io", id)
+	}
+
+	channel, err := newChannel(*channels[channelIdx])
+	if err != nil {
+		return ChannelModel{}, err
+	}
+
+	return channel, nil
+}
+
+// Creates a new channel.
+// Currently this function is NOT cancelable.
+func (m *ChannelModel) Create(_ context.Context, client *Client) error {
+	channelParam := m.mackerelChannel()
+	channel, err := client.CreateChannel(&channelParam)
+	if err != nil {
+		return err
+	}
+
+	m.ID = types.StringValue(channel.ID)
+	return nil
+}
+
+// Reads a channel.
+// Currently this function is NOT cancelable.
+func (m *ChannelModel) Read(ctx context.Context, client *Client) error {
+	newModel, err := ReadChannel(ctx, client, m.ID.ValueString())
+	if err != nil {
+		return err
+	}
+
+	m.merge(newModel)
+	return nil
+}
+
+// Deletes a channel.
+func (m *ChannelModel) Delete(_ context.Context, client *Client) error {
+	if _, err := client.DeleteChannel(m.ID.ValueString()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func newChannel(mackerelChannel mackerel.Channel) (ChannelModel, error) {
+	model := ChannelModel{
+		ID:   types.StringValue(mackerelChannel.ID),
+		Name: types.StringValue(mackerelChannel.Name),
+	}
+	switch mackerelChannel.Type {
+	case "email":
+		model.Email = []ChannelEmailModel{{
+			Emails:  *mackerelChannel.Emails,
+			UserIDs: *mackerelChannel.UserIDs,
+			Events:  *mackerelChannel.Events,
+		}}
+		return model, nil
+	case "slack":
+		slackModel := ChannelSlackModel{
+			URL:               types.StringValue(mackerelChannel.URL),
+			EnabledGraphImage: types.BoolPointerValue(mackerelChannel.EnabledGraphImage),
+			Events:            *mackerelChannel.Events,
+		}
+		if mackerelChannel.Mentions != (mackerel.Mentions{}) {
+			mentions := make(map[string]string, 3)
+			if mackerelChannel.Mentions.OK != "" {
+				mentions["ok"] = mackerelChannel.Mentions.OK
+			}
+			if mackerelChannel.Mentions.Warning != "" {
+				mentions["warning"] = mackerelChannel.Mentions.Warning
+			}
+			if mackerelChannel.Mentions.Critical != "" {
+				mentions["critical"] = mackerelChannel.Mentions.Critical
+			}
+			slackModel.Mentions = mentions
+		}
+		model.Slack = []ChannelSlackModel{slackModel}
+		return model, nil
+	case "webhook":
+		model.Webhook = []ChannelWebhookModel{{
+			URL:    types.StringValue(mackerelChannel.URL),
+			Events: *mackerelChannel.Events,
+		}}
+		return model, nil
+	default:
+		return ChannelModel{}, fmt.Errorf("unsupported channel type: %s", mackerelChannel.Type)
+	}
+}
+
+func (m ChannelModel) mackerelChannel() mackerel.Channel {
+	channel := mackerel.Channel{
+		ID:     m.ID.ValueString(),
+		Name:   m.Name.ValueString(),
+		Events: &[]string{},
+	}
+	if len(m.Email) > 0 {
+		emailModel := m.Email[0]
+		channel.Type = "email"
+		if len(emailModel.Emails) > 0 {
+			channel.Emails = &emailModel.Emails
+		} else {
+			channel.Emails = &[]string{}
+		}
+		if len(emailModel.UserIDs) > 0 {
+			channel.UserIDs = &emailModel.UserIDs
+		} else {
+			channel.UserIDs = &[]string{}
+		}
+		if len(emailModel.Events) > 0 {
+			channel.Events = &emailModel.Events
+		}
+	} else if len(m.Slack) > 0 {
+		slackModel := m.Slack[0]
+		channel.Type = "slack"
+		channel.URL = slackModel.URL.ValueString()
+		if slackModel.Mentions != nil {
+			if okMention, ok := slackModel.Mentions["ok"]; ok {
+				channel.Mentions.OK = okMention
+			}
+			if warnMention, ok := slackModel.Mentions["warning"]; ok {
+				channel.Mentions.Warning = warnMention
+			}
+			if critMention, ok := slackModel.Mentions["critical"]; ok {
+				channel.Mentions.Critical = critMention
+			}
+		}
+		channel.EnabledGraphImage = slackModel.EnabledGraphImage.ValueBoolPointer()
+		if len(slackModel.Events) > 0 {
+			channel.Events = &slackModel.Events
+		}
+	} else if len(m.Webhook) > 0 {
+		webhookModel := m.Webhook[0]
+		channel.Type = "webhook"
+		channel.URL = webhookModel.URL.ValueString()
+		if len(webhookModel.Events) > 0 {
+			channel.Events = &webhookModel.Events
+		}
+	}
+	return channel
+}
+
+func (m *ChannelModel) merge(newModel ChannelModel) {
+	if len(m.Email) > 0 && len(newModel.Email) > 0 {
+		oldEmail := m.Email[0]
+		newEmail := &newModel.Email[0]
+
+		// Distinct between null and [] in email.emails
+		// If both side of emails are empty, preserve old one.
+		if len(oldEmail.Emails) == 0 && len(newEmail.Emails) == 0 {
+			newEmail.Emails = oldEmail.Emails
+		}
+
+		// Distinct between null and [] in email.user_ids
+		if len(oldEmail.UserIDs) == 0 && len(newEmail.UserIDs) == 0 {
+			newEmail.UserIDs = oldEmail.UserIDs
+		}
+
+		// Distinct between null and [] in email.events
+		if len(oldEmail.Events) == 0 && len(newEmail.Events) == 0 {
+			newEmail.Events = oldEmail.Events
+		}
+	}
+	if len(m.Slack) > 0 && len(newModel.Slack) > 0 {
+		oldSlack := m.Slack[0]
+		newSlack := &newModel.Slack[0]
+
+		// Distinct between null and {} in slack.mentions
+		if len(oldSlack.Mentions) == 0 && len(newSlack.Mentions) == 0 {
+			newSlack.Mentions = oldSlack.Mentions
+		}
+
+		// Distinct between null and [] in slack.events
+		if len(oldSlack.Events) == 0 && len(newSlack.Events) == 0 {
+			newSlack.Events = oldSlack.Events
+		}
+	}
+	if len(m.Webhook) > 0 && len(newModel.Webhook) > 0 {
+		// Distinct between null and [] in webhook.events
+		if len(m.Webhook[0].Events) == 0 && len(newModel.Webhook[0].Events) == 0 {
+			newModel.Webhook[0].Events = m.Webhook[0].Events
+		}
+	}
+
+	*m = newModel
+}

--- a/internal/mackerel/channel_test.go
+++ b/internal/mackerel/channel_test.go
@@ -1,0 +1,246 @@
+package mackerel
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+const (
+	testChannelSlackURL   = "https://slack.test/services/xxx/yyy/zzz"
+	testChannelWebhookURL = "https://example.test/hook"
+)
+
+func Test_Channel_conv(t *testing.T) {
+	t.Parallel()
+
+	// api <-> model
+	cases := map[string]struct {
+		api   mackerel.Channel
+		model ChannelModel
+	}{
+		"slack": {
+			api: mackerel.Channel{
+				ID:                "5eKHBxJS5u9",
+				Name:              "slack",
+				Type:              "slack",
+				Mentions:          mackerel.Mentions{},
+				EnabledGraphImage: ptr(false),
+				URL:               testChannelSlackURL,
+				Events:            ptr([]string{}),
+			},
+
+			model: ChannelModel{
+				ID:   types.StringValue("5eKHBxJS5u9"),
+				Name: types.StringValue("slack"),
+				Slack: []ChannelSlackModel{{
+					URL:               types.StringValue(testChannelSlackURL),
+					EnabledGraphImage: types.BoolValue(false),
+					Events:            []string{},
+				}},
+			},
+		},
+		"slack-full": {
+			api: mackerel.Channel{
+				ID:   "5eKHBxJS5u9",
+				Name: "slack-full",
+				Type: "slack",
+				Mentions: mackerel.Mentions{
+					OK:       "OK!!!",
+					Warning:  "WARNING!!!",
+					Critical: "CRITICAL!!!",
+				},
+				EnabledGraphImage: ptr(true),
+				URL:               testChannelSlackURL,
+				Events:            ptr([]string{"alert"}),
+			},
+
+			model: ChannelModel{
+				ID:   types.StringValue("5eKHBxJS5u9"),
+				Name: types.StringValue("slack-full"),
+				Slack: []ChannelSlackModel{{
+					URL: types.StringValue(testChannelSlackURL),
+					Mentions: map[string]string{
+						"ok":       "OK!!!",
+						"warning":  "WARNING!!!",
+						"critical": "CRITICAL!!!",
+					},
+					EnabledGraphImage: types.BoolValue(true),
+					Events:            []string{"alert"},
+				}},
+			},
+		},
+		"webhook": {
+			api: mackerel.Channel{
+				ID:     "5eKHBxRHcMJ",
+				Name:   "webhook",
+				Type:   "webhook",
+				URL:    testChannelWebhookURL,
+				Events: ptr([]string{}),
+			},
+			model: ChannelModel{
+				ID:   types.StringValue("5eKHBxRHcMJ"),
+				Name: types.StringValue("webhook"),
+				Webhook: []ChannelWebhookModel{{
+					URL:    types.StringValue(testChannelWebhookURL),
+					Events: []string{},
+				}},
+			},
+		},
+		"email": {
+			api: mackerel.Channel{
+				ID:      "5eKHBzgCmAd",
+				Name:    "email",
+				Type:    "email",
+				Emails:  ptr([]string{"john.doe@example.test"}),
+				UserIDs: ptr([]string{"john"}),
+				Events:  ptr([]string{"alertGroup"}),
+			},
+			model: ChannelModel{
+				ID:   types.StringValue("5eKHBzgCmAd"),
+				Name: types.StringValue("email"),
+				Email: []ChannelEmailModel{{
+					Emails:  []string{"john.doe@example.test"},
+					UserIDs: []string{"john"},
+					Events:  []string{"alertGroup"},
+				}},
+			},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name+"-toModel", func(t *testing.T) {
+			t.Parallel()
+
+			m, err := newChannel(tt.api)
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(m, tt.model); diff != "" {
+				t.Error(diff)
+			}
+		})
+		t.Run(name+"-toAPI", func(t *testing.T) {
+			t.Parallel()
+
+			c := tt.model.mackerelChannel()
+			if diff := cmp.Diff(c, tt.api); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func Test_Channel_merge(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		in    ChannelModel
+		inNew ChannelModel
+		wants ChannelModel
+	}{
+		"slack": {
+			in: ChannelModel{
+				ID:   types.StringValue("5eKHBxJS5u9"),
+				Name: types.StringValue("slack"),
+				Slack: []ChannelSlackModel{{
+					URL:               types.StringValue(testChannelSlackURL),
+					EnabledGraphImage: types.BoolValue(false),
+					Events:            nil,
+				}},
+			},
+			inNew: ChannelModel{
+				ID:   types.StringValue("5eKHBxJS5u9"),
+				Name: types.StringValue("slack"),
+				Slack: []ChannelSlackModel{{
+					URL:               types.StringValue(testChannelSlackURL),
+					EnabledGraphImage: types.BoolValue(true), // changed
+					Events:            []string{},
+				}},
+			},
+			wants: ChannelModel{
+				ID:   types.StringValue("5eKHBxJS5u9"),
+				Name: types.StringValue("slack"),
+				Slack: []ChannelSlackModel{{
+					URL:               types.StringValue(testChannelSlackURL),
+					EnabledGraphImage: types.BoolValue(true),
+					Events:            nil, // preserved
+				}},
+			},
+		},
+		"webhook": {
+			in: ChannelModel{
+				ID:   types.StringValue("5eKHBxRHcMJ"),
+				Name: types.StringValue("webhook"),
+				Webhook: []ChannelWebhookModel{{
+					URL:    types.StringValue(testChannelWebhookURL),
+					Events: nil,
+				}},
+			},
+			inNew: ChannelModel{
+				ID:   types.StringValue("5eKHBxRHcMJ"),
+				Name: types.StringValue("webhook-changed"),
+				Webhook: []ChannelWebhookModel{{
+					URL:    types.StringValue(testChannelWebhookURL),
+					Events: []string{},
+				}},
+			},
+			wants: ChannelModel{
+				ID:   types.StringValue("5eKHBxRHcMJ"),
+				Name: types.StringValue("webhook-changed"),
+				Webhook: []ChannelWebhookModel{{
+					URL:    types.StringValue(testChannelWebhookURL),
+					Events: nil,
+				}},
+			},
+		},
+		"email": {
+			in: ChannelModel{
+				ID:   types.StringValue("5eKHBzgCmAd"),
+				Name: types.StringValue("email"),
+				Email: []ChannelEmailModel{{
+					Emails:  nil,
+					UserIDs: nil,
+					Events:  nil,
+				}},
+			},
+			inNew: ChannelModel{
+				ID:   types.StringValue("5eKHBzgCmAd"),
+				Name: types.StringValue("email-changed"),
+				Email: []ChannelEmailModel{{
+					Emails:  []string{},
+					UserIDs: []string{},
+					Events:  []string{},
+				}},
+			},
+			wants: ChannelModel{
+				ID:   types.StringValue("5eKHBzgCmAd"),
+				Name: types.StringValue("email-changed"),
+				Email: []ChannelEmailModel{{
+					Emails:  nil,
+					UserIDs: nil,
+					Events:  nil,
+				}},
+			},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			m := tt.in
+			m.merge(tt.inNew)
+			if diff := cmp.Diff(m, tt.wants); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func ptr[T any](x T) *T {
+	return &x
+}

--- a/internal/provider/data_source_mackerel_channel.go
+++ b/internal/provider/data_source_mackerel_channel.go
@@ -1,0 +1,122 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel"
+)
+
+var (
+	_ datasource.DataSource              = (*mackerelChannelDataSource)(nil)
+	_ datasource.DataSourceWithConfigure = (*mackerelChannelDataSource)(nil)
+)
+
+func NewMackerelChannelDataSource() datasource.DataSource {
+	return &mackerelChannelDataSource{}
+}
+
+type mackerelChannelDataSource struct {
+	Client *mackerel.Client
+}
+
+func (d *mackerelChannelDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_channel"
+}
+
+func (d *mackerelChannelDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schemaChannelDataSource()
+}
+
+func (d *mackerelChannelDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	client, diags := retrieveClient(ctx, req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+	d.Client = client
+}
+
+func (d *mackerelChannelDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config mackerel.ChannelModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data, err := mackerel.ReadChannel(ctx, d.Client, config.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to read a channel",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func schemaChannelDataSource() schema.Schema {
+	schema := schema.Schema{
+		Description: "This data source allows access to details of a specific notification channel.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: schemaChannelIDDesc,
+				Required:    true,
+			},
+			"name": schema.StringAttribute{
+				Description: schemaChannelNameDesc,
+				Computed:    true,
+			},
+			"email": schema.ListAttribute{
+				Description: schemaChannelEmailDesc,
+				Computed:    true,
+				ElementType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"emails": types.SetType{
+							ElemType: types.StringType,
+						},
+						"user_ids": types.SetType{
+							ElemType: types.StringType,
+						},
+						"events": types.SetType{
+							ElemType: types.StringType,
+						},
+					},
+				},
+			},
+			"slack": schema.ListAttribute{
+				Description: schemaChannelSlackDesc,
+				Computed:    true,
+				ElementType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"url": types.StringType,
+						"mentions": types.MapType{
+							ElemType: types.StringType,
+						},
+						"enabled_graph_image": types.BoolType,
+						"events": types.SetType{
+							ElemType: types.StringType,
+						},
+					},
+				},
+			},
+			"webhook": schema.ListAttribute{
+				Description: schemaChannelWebhookDesc,
+				Computed:    true,
+				ElementType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"url": types.StringType,
+						"events": types.SetType{
+							ElemType: types.StringType,
+						},
+					},
+				},
+			},
+		},
+	}
+	return schema
+}

--- a/internal/provider/data_source_mackerel_channel_test.go
+++ b/internal/provider/data_source_mackerel_channel_test.go
@@ -1,0 +1,26 @@
+package provider_test
+
+import (
+	"context"
+	"testing"
+
+	fwdatasource "github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider"
+)
+
+func Test_MackerelChannelDataSource_schema(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	req := fwdatasource.SchemaRequest{}
+	resp := fwdatasource.SchemaResponse{}
+	provider.NewMackerelChannelDataSource().Schema(ctx, req, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %+v", resp.Diagnostics)
+	}
+
+	if diags := resp.Schema.ValidateImplementation(ctx); diags.HasError() {
+		t.Fatalf("schema validation diagnostics: %+v", diags)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -83,6 +83,7 @@ func (m *mackerelProvider) Configure(ctx context.Context, req provider.Configure
 
 func (m *mackerelProvider) Resources(context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
+		NewMackerelChannelResource,
 		NewMackerelMonitorResource,
 		NewMackerelNotificationGroupResource,
 		NewMackerelRoleResource,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -95,6 +95,7 @@ func (m *mackerelProvider) Resources(context.Context) []func() resource.Resource
 
 func (m *mackerelProvider) DataSources(context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
+		NewMackerelChannelDataSource,
 		NewMackerelMonitorDataSource,
 		NewMackerelNotificationGroupDataSource,
 		NewMackerelRoleDataSource,

--- a/internal/provider/resource_mackerel_channel.go
+++ b/internal/provider/resource_mackerel_channel.go
@@ -1,0 +1,292 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/validatorutil"
+)
+
+var (
+	_ resource.Resource                     = (*mackerelChannelResource)(nil)
+	_ resource.ResourceWithConfigValidators = (*mackerelChannelResource)(nil)
+	_ resource.ResourceWithConfigure        = (*mackerelChannelResource)(nil)
+	_ resource.ResourceWithImportState      = (*mackerelChannelResource)(nil)
+)
+
+func NewMackerelChannelResource() resource.Resource {
+	return &mackerelChannelResource{}
+}
+
+type mackerelChannelResource struct {
+	Client *mackerel.Client
+}
+
+func (r *mackerelChannelResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_channel"
+}
+
+func (r *mackerelChannelResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema, _ = schemaChannelResource()
+}
+
+func (r *mackerelChannelResource) ConfigValidators(context.Context) []resource.ConfigValidator {
+	_, validators := schemaChannelResource()
+	return validators
+}
+
+func (r *mackerelChannelResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	client, diags := retrieveClient(ctx, req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+	r.Client = client
+}
+
+func (r *mackerelChannelResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data mackerel.ChannelModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Create(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to create a channel",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *mackerelChannelResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data mackerel.ChannelModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Read(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to read a channel",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *mackerelChannelResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+}
+
+func (r *mackerelChannelResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data mackerel.ChannelModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Delete(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to delete a channel",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *mackerelChannelResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+const (
+	schemaChannelIDDesc     = "The ID of the notification channel."
+	schemaChannelNameDesc   = "The name of the notification channel."
+	schemaChannelEventsDesc = "The set of notification event types to be received."
+
+	schemaChannelEmailDesc         = "The settings for an email notification channel."
+	schemaChannelEmail_EmailsDesc  = "The set of email addresses specified to receive notifications."
+	schemaChannelEmail_UserIDsDesc = "The set of user IDs specified to receive notifications."
+
+	schemaChannelSlackDesc          = "The settings for a slack notification channel."
+	schemaChannelSlack_URLDesc      = "The incoming webhook URL for Slack."
+	schemaChannelSlack_MentionsDesc = "The map of the condition (ok, warning, critical)" +
+		"and the text accompanying the alert notification."
+	schemaChannelSlack_EnabledGraphImageDesc = "Whether or not the corresponding graph is posted to Slack."
+
+	schemaChannelWebhookDesc     = "The settings for a webhook notification channel."
+	schemaChannelWebhook_URLDesc = "The URL that will receive HTTP request."
+)
+
+func schemaChannelResource() (schema.Schema, []resource.ConfigValidator) {
+	eventsAttr := schema.SetAttribute{
+		Description: schemaChannelEventsDesc,
+		ElementType: types.StringType,
+		Optional:    true,
+		Validators: []validator.Set{setvalidator.ValueStringsAre(
+			stringvalidator.OneOf(
+				"alert",
+				"alertGroup",
+				"hostStatus",
+				"hostRegister",
+				"hostRetire",
+				"monitor",
+			),
+		)},
+		PlanModifiers: []planmodifier.Set{
+			setplanmodifier.RequiresReplace(),
+		},
+	}
+	schema := schema.Schema{
+		Description: "This resource allows creating and management of channel, which manages either email, slack or webhook.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: schemaChannelIDDesc,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(), // immutable
+				},
+			},
+			"name": schema.StringAttribute{
+				Description: schemaChannelNameDesc,
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"email": schema.ListNestedBlock{
+				Description: schemaChannelEmailDesc,
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.RequiresReplace(),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"emails": schema.SetAttribute{
+							ElementType: types.StringType,
+							Description: schemaChannelEmail_EmailsDesc,
+							Optional:    true,
+							PlanModifiers: []planmodifier.Set{
+								setplanmodifier.RequiresReplace(),
+							},
+						},
+						"user_ids": schema.SetAttribute{
+							ElementType: types.StringType,
+							Description: schemaChannelEmail_UserIDsDesc,
+							Optional:    true,
+							PlanModifiers: []planmodifier.Set{
+								setplanmodifier.RequiresReplace(),
+							},
+						},
+						"events": eventsAttr,
+					},
+				},
+			},
+			"slack": schema.ListNestedBlock{
+				Description: schemaChannelSlackDesc,
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.RequiresReplace(),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"url": schema.StringAttribute{
+							Description: schemaChannelSlack_URLDesc,
+							Required:    true,
+							Validators: []validator.String{
+								validatorutil.IsURLWithHTTPorHTTPS(),
+							},
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+							},
+						},
+						// FIXME(needs schema upgrade): use nested attribute
+						"mentions": schema.MapAttribute{
+							ElementType: types.StringType,
+							Description: schemaChannelSlack_MentionsDesc,
+							Optional:    true,
+							Validators: []validator.Map{
+								mapvalidator.KeysAre(stringvalidator.OneOf("ok", "warning", "critical")),
+								mapvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
+							},
+							PlanModifiers: []planmodifier.Map{
+								mapplanmodifier.RequiresReplace(),
+							},
+						},
+						"enabled_graph_image": schema.BoolAttribute{
+							Description: schemaChannelSlack_EnabledGraphImageDesc,
+							Optional:    true,
+							Computed:    true,
+							Default:     booldefault.StaticBool(false),
+							PlanModifiers: []planmodifier.Bool{
+								boolplanmodifier.RequiresReplace(),
+							},
+						},
+						"events": eventsAttr,
+					},
+				},
+			},
+			"webhook": schema.ListNestedBlock{
+				Description: schemaChannelWebhookDesc,
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.RequiresReplace(),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"url": schema.StringAttribute{
+							Description: schemaChannelWebhook_URLDesc,
+							Required:    true,
+							Validators: []validator.String{
+								validatorutil.IsURLWithHTTPorHTTPS(),
+							},
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+							},
+						},
+						"events": eventsAttr,
+					},
+				},
+			},
+		},
+	}
+	validators := []resource.ConfigValidator{
+		resourcevalidator.ExactlyOneOf(
+			path.MatchRoot("email"),
+			path.MatchRoot("slack"),
+			path.MatchRoot("webhook"),
+		),
+	}
+	return schema, validators
+}

--- a/internal/provider/resource_mackerel_channel_test.go
+++ b/internal/provider/resource_mackerel_channel_test.go
@@ -1,0 +1,26 @@
+package provider_test
+
+import (
+	"context"
+	"testing"
+
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider"
+)
+
+func Test_MackerelChannelResource_schema(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	req := fwresource.SchemaRequest{}
+	resp := fwresource.SchemaResponse{}
+	provider.NewMackerelChannelResource().Schema(ctx, req, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %+v", resp.Diagnostics)
+	}
+
+	if diags := resp.Schema.ValidateImplementation(ctx); diags.HasError() {
+		t.Fatalf("schema validation diagnostics: %+v", diags)
+	}
+}

--- a/mackerel/provider.go
+++ b/mackerel/provider.go
@@ -82,6 +82,7 @@ func protoV5ProviderServer(provider *schema.Provider) tfprotov5.ProviderServer {
 		log.Printf("[INFO] mackerel: use terraform-plugin-framework based implementation")
 
 		// Resources
+		delete(provider.ResourcesMap, "mackerel_channel")
 		delete(provider.ResourcesMap, "mackerel_monitor")
 		delete(provider.ResourcesMap, "mackerel_notification_group")
 		delete(provider.ResourcesMap, "mackerel_role")

--- a/mackerel/provider.go
+++ b/mackerel/provider.go
@@ -91,6 +91,7 @@ func protoV5ProviderServer(provider *schema.Provider) tfprotov5.ProviderServer {
 		delete(provider.ResourcesMap, "mackerel_service_metadata")
 
 		// Data Sources
+		delete(provider.DataSourcesMap, "mackerel_channel")
 		delete(provider.DataSourcesMap, "mackerel_monitor")
 		delete(provider.DataSourcesMap, "mackerel_notification_group")
 		delete(provider.DataSourcesMap, "mackerel_role")


### PR DESCRIPTION
Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ MACKEREL_EXPERIMENTAL_TFFRAMEWORK=1 make testacc TESTS='"Acc(DataSource)?MackerelChannel"'
TF_ACC=1 go test -v ./mackerel/... -run "Acc(DataSource)?MackerelChannel" -timeout 120m
2024/08/28 16:15:56 [INFO] mackerel: use terraform-plugin-framework based implementation
=== RUN   TestAccDataSourceMackerelChannelEmail
=== PAUSE TestAccDataSourceMackerelChannelEmail
=== RUN   TestAccDataSourceMackerelChannelSlack
=== PAUSE TestAccDataSourceMackerelChannelSlack
=== RUN   TestAccDataSourceMackerelChannelWebhook
=== PAUSE TestAccDataSourceMackerelChannelWebhook
=== RUN   TestAccDataSourceMackerelChannelNotMatchAnyChannel
=== PAUSE TestAccDataSourceMackerelChannelNotMatchAnyChannel
=== RUN   TestAccMackerelChannel_Email
=== PAUSE TestAccMackerelChannel_Email
=== RUN   TestAccMackerelChannel_Slack
=== PAUSE TestAccMackerelChannel_Slack
=== RUN   TestAccMackerelChannel_Webhook
=== PAUSE TestAccMackerelChannel_Webhook
=== CONT  TestAccDataSourceMackerelChannelEmail
=== CONT  TestAccMackerelChannel_Email
=== CONT  TestAccMackerelChannel_Webhook
=== CONT  TestAccMackerelChannel_Slack
=== CONT  TestAccDataSourceMackerelChannelWebhook
=== CONT  TestAccDataSourceMackerelChannelNotMatchAnyChannel
=== CONT  TestAccDataSourceMackerelChannelSlack
--- PASS: TestAccDataSourceMackerelChannelNotMatchAnyChannel (3.98s)
--- PASS: TestAccDataSourceMackerelChannelEmail (8.08s)
--- PASS: TestAccDataSourceMackerelChannelWebhook (8.35s)
--- PASS: TestAccDataSourceMackerelChannelSlack (8.35s)
--- PASS: TestAccMackerelChannel_Webhook (12.38s)
--- PASS: TestAccMackerelChannel_Email (12.62s)
--- PASS: TestAccMackerelChannel_Slack (12.73s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel 13.791s
```
