### PR TITLE
Reimplement dashboards with terraform-plugin-framework

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/golangci/golangci-lint v1.50.1
 	github.com/google/go-cmp v0.6.0
-	github.com/hashicorp/terraform-plugin-framework v1.8.0
+	github.com/hashicorp/terraform-plugin-framework v1.11.0
 	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.1.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -342,6 +342,8 @@ github.com/hashicorp/terraform-json v0.22.1 h1:xft84GZR0QzjPVWs4lRUwvTcPnegqlyS7
 github.com/hashicorp/terraform-json v0.22.1/go.mod h1:JbWSQCLFSXFFhg42T7l9iJwdGXBYV8fmmD6o/ML4p3A=
 github.com/hashicorp/terraform-plugin-framework v1.8.0 h1:P07qy8RKLcoBkCrY2RHJer5AEvJnDuXomBgou6fD8kI=
 github.com/hashicorp/terraform-plugin-framework v1.8.0/go.mod h1:/CpTukO88PcL/62noU7cuyaSJ4Rsim+A/pa+3rUVufY=
+github.com/hashicorp/terraform-plugin-framework v1.11.0 h1:M7+9zBArexHFXDx/pKTxjE6n/2UCXY6b8FIq9ZYhwfE=
+github.com/hashicorp/terraform-plugin-framework v1.11.0/go.mod h1:qBXLDn69kM97NNVi/MQ9qgd1uWWsVftGSnygYG1tImM=
 github.com/hashicorp/terraform-plugin-framework-jsontypes v0.1.0 h1:b8vZYB/SkXJT4YPbT3trzE6oJ7dPyMy68+9dEDKsJjE=
 github.com/hashicorp/terraform-plugin-framework-jsontypes v0.1.0/go.mod h1:tP9BC3icoXBz72evMS5UTFvi98CiKhPdXF6yLs1wS8A=
 github.com/hashicorp/terraform-plugin-framework-validators v0.12.0 h1:HOjBuMbOEzl7snOdOoUfE2Jgeto6JOjLVQ39Ls2nksc=

--- a/internal/mackerel/dashboard.go
+++ b/internal/mackerel/dashboard.go
@@ -1,0 +1,514 @@
+package mackerel
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+type (
+	DashboardModel struct {
+		ID        types.String `tfsdk:"id"`
+		Title     types.String `tfsdk:"title"`
+		Memo      types.String `tfsdk:"memo"`
+		URLPath   types.String `tfsdk:"url_path"`
+		CreatedAt types.Int64  `tfsdk:"created_at"`
+		UpdatedAt types.Int64  `tfsdk:"updated_at"`
+
+		Graph       []DashboardWidgetGraph       `tfsdk:"graph"`
+		Value       []DashboardWidgetValue       `tfsdk:"value"`
+		Markdown    []DashboardWidgetMarkdown    `tfsdk:"markdown"`
+		AlertStatus []DashboardWidgetAlertStatus `tfsdk:"alert_status"`
+	}
+
+	DashboardLayout struct {
+		X      types.Int64 `tfsdk:"x"`
+		Y      types.Int64 `tfsdk:"y"`
+		Width  types.Int64 `tfsdk:"width"`
+		Height types.Int64 `tfsdk:"height"`
+	}
+	dashboardWidget struct {
+		Title  types.String      `tfsdk:"title"`
+		Layout []DashboardLayout `tfsdk:"layout"`
+	}
+
+	DashboardWidgetGraph struct {
+		dashboardWidget
+		Range []DashboardRange `tfsdk:"range"`
+
+		Host       []DashboardGraphHost       `tfsdk:"host"`
+		Role       []DashboardGraphRole       `tfsdk:"role"`
+		Service    []DashboardGraphService    `tfsdk:"service"`
+		Expression []DashboardGraphExpression `tfsdk:"expression"`
+		Query      []DashboardGraphQuery      `tfsdk:"query"`
+	}
+	DashboardRange struct {
+		Relative []DashboardRangeRelative `tfsdk:"relative"`
+		Absolute []DashboardRangeAbsolute `tfsdk:"absolute"`
+	}
+	DashboardRangeRelative struct {
+		Period types.Int64 `tfsdk:"period"`
+		Offset types.Int64 `tfsdk:"offset"`
+	}
+	DashboardRangeAbsolute struct {
+		Start types.Int64 `tfsdk:"start"`
+		End   types.Int64 `tfsdk:"end"`
+	}
+	DashboardGraphHost struct {
+		HostID types.String `tfsdk:"host_id"`
+		Name   types.String `tfsdk:"name"`
+	}
+	DashboardGraphRole struct {
+		RoleFullname types.String `tfsdk:"role_fullname"`
+		Name         types.String `tfsdk:"name"`
+		IsStacked    types.Bool   `tfsdk:"is_stacked"`
+	}
+	DashboardGraphService struct {
+		ServiceName types.String `tfsdk:"service_name"`
+		Name        types.String `tfsdk:"name"`
+	}
+	DashboardGraphExpression struct {
+		Expression types.String `tfsdk:"expression"`
+	}
+	DashboardGraphQuery struct {
+		Query  types.String `tfsdk:"query"`
+		Legend types.String `tfsdk:"legend"`
+	}
+
+	DashboardWidgetValue struct {
+		dashboardWidget
+		Metric       []DashboardMetric `tfsdk:"metric"`
+		FractionSize types.Int64       `tfsdk:"fraction_size"`
+		Suffix       types.String      `tfsdk:"suffix"`
+	}
+	DashboardMetric struct {
+		Host       []DashboardMetricHost       `tfsdk:"host"`
+		Service    []DashboardMetricService    `tfsdk:"service"`
+		Expression []DashboardMetricExpression `tfsdk:"expression"`
+		Query      []DashboardMetricQuery      `tfsdk:"query"`
+	}
+	DashboardMetricHost struct {
+		HostID types.String `tfsdk:"host_id"`
+		Name   types.String `tfsdk:"name"`
+	}
+	DashboardMetricService struct {
+		ServiceName types.String `tfsdk:"service_name"`
+		Name        types.String `tfsdk:"name"`
+	}
+	DashboardMetricExpression struct {
+		Expression types.String `tfsdk:"expression"`
+	}
+	DashboardMetricQuery struct {
+		Query  types.String `tfsdk:"query"`
+		Legend types.String `tfsdk:"legend"`
+	}
+
+	DashboardWidgetMarkdown struct {
+		dashboardWidget
+		Markdown types.String `tfsdk:"markdown"`
+	}
+
+	DashboardWidgetAlertStatus struct {
+		dashboardWidget
+		RoleFullname types.String `tfsdk:"role_fullname"`
+	}
+)
+
+func ReadDashboard(_ context.Context, client *Client, id string) (DashboardModel, error) {
+	d, err := client.FindDashboard(id)
+	if err != nil {
+		return DashboardModel{}, err
+	}
+	return newDashboard(*d)
+}
+
+func (d *DashboardModel) Create(_ context.Context, client *Client) error {
+	param := d.mackerelDashboard()
+	md, err := client.CreateDashboard(&param)
+	if err != nil {
+		return err
+	}
+	d.ID = types.StringValue(md.ID)
+	d.CreatedAt = types.Int64Value(md.CreatedAt)
+	d.UpdatedAt = types.Int64Value(md.UpdatedAt)
+	return nil
+}
+
+func (d *DashboardModel) Read(ctx context.Context, client *Client) error {
+	nd, err := ReadDashboard(ctx, client, d.ID.ValueString())
+	if err != nil {
+		return err
+	}
+	*d = nd
+	return nil
+}
+
+func (d *DashboardModel) Update(_ context.Context, client *Client) error {
+	param := d.mackerelDashboard()
+	md, err := client.UpdateDashboard(d.ID.ValueString(), &param)
+	if err != nil {
+		return err
+	}
+	d.UpdatedAt = types.Int64Value(md.UpdatedAt)
+	return nil
+}
+
+func (d DashboardModel) Delete(_ context.Context, client *Client) error {
+	if _, err := client.DeleteDashboard(d.ID.ValueString()); err != nil {
+		return err
+	}
+	return nil
+}
+
+const (
+	dashboardWidgetTypeGraph       = "graph"
+	dashboardWidgetTypeValue       = "value"
+	dashboardWidgetTypeMarkdown    = "markdown"
+	dashboardWidgetTypeAlertStatus = "alertStatus"
+
+	dashboardGraphTypeHost       = "host"
+	dashboardGraphTypeRole       = "role"
+	dashboardGraphTypeService    = "service"
+	dashboardGraphTypeExpression = "expression"
+	dashboardGraphTypeQuery      = "query"
+
+	dashboardRangeTypeRelative = "relative"
+	dashboardRangeTypeAbsolute = "absolute"
+
+	dashboardMetricTypeHost       = "host"
+	dashboardMetricTypeService    = "service"
+	dashboardMetricTypeExpression = "expression"
+	dashboardMetricTypeQuery      = "query"
+)
+
+func newDashboard(d mackerel.Dashboard) (DashboardModel, error) {
+	m := DashboardModel{
+		ID:        types.StringValue(d.ID),
+		Title:     types.StringValue(d.Title),
+		Memo:      types.StringValue(d.Memo),
+		URLPath:   types.StringValue(d.URLPath),
+		CreatedAt: types.Int64Value(d.CreatedAt),
+		UpdatedAt: types.Int64Value(d.UpdatedAt),
+
+		Graph:       []DashboardWidgetGraph{},
+		Value:       []DashboardWidgetValue{},
+		Markdown:    []DashboardWidgetMarkdown{},
+		AlertStatus: []DashboardWidgetAlertStatus{},
+	}
+
+	for _, w := range d.Widgets {
+		switch w.Type {
+		case dashboardWidgetTypeGraph:
+			wg, err := newDashboardWidgetGraph(w)
+			if err != nil {
+				return m, err
+			}
+			m.Graph = append(m.Graph, wg)
+		case dashboardWidgetTypeValue:
+			wv, err := newDashboardWidgetValue(w)
+			if err != nil {
+				return m, err
+			}
+			m.Value = append(m.Value, wv)
+		case dashboardWidgetTypeMarkdown:
+			wm, err := newDashboardWidgetMarkdown(w)
+			if err != nil {
+				return m, err
+			}
+			m.Markdown = append(m.Markdown, wm)
+		case dashboardWidgetTypeAlertStatus:
+			was, err := newDashboardWidgetAlertStatus(w)
+			if err != nil {
+				return m, err
+			}
+			m.AlertStatus = append(m.AlertStatus, was)
+		default:
+			return m, fmt.Errorf("unsupported widget type: %q", w.Type)
+		}
+	}
+
+	return m, nil
+}
+
+func (d DashboardModel) mackerelDashboard() mackerel.Dashboard {
+	md := mackerel.Dashboard{
+		ID:        d.ID.ValueString(),
+		Title:     d.Title.ValueString(),
+		Memo:      d.Memo.ValueString(),
+		URLPath:   d.URLPath.ValueString(),
+		CreatedAt: d.CreatedAt.ValueInt64(),
+		UpdatedAt: d.UpdatedAt.ValueInt64(),
+		Widgets:   make([]mackerel.Widget, 0, len(d.Graph)+len(d.Value)+len(d.Markdown)+len(d.AlertStatus)),
+	}
+	for _, g := range d.Graph {
+		md.Widgets = append(md.Widgets, g.mackerelWidget())
+	}
+	for _, v := range d.Value {
+		md.Widgets = append(md.Widgets, v.mackerelWidget())
+	}
+	for _, m := range d.Markdown {
+		md.Widgets = append(md.Widgets, m.mackerelWidget())
+	}
+	for _, a := range d.AlertStatus {
+		md.Widgets = append(md.Widgets, a.mackerelWidget())
+	}
+	return md
+}
+
+func newDashboardWidget(w mackerel.Widget) dashboardWidget {
+	return dashboardWidget{
+		Title: types.StringValue(w.Title),
+		Layout: []DashboardLayout{{
+			X:      types.Int64Value(w.Layout.X),
+			Y:      types.Int64Value(w.Layout.Y),
+			Width:  types.Int64Value(w.Layout.Width),
+			Height: types.Int64Value(w.Layout.Height),
+		}},
+	}
+}
+
+func (w dashboardWidget) mackerelWidget() mackerel.Widget {
+	return mackerel.Widget{
+		Title: w.Title.ValueString(),
+		Layout: mackerel.Layout{
+			X:      w.Layout[0].X.ValueInt64(),
+			Y:      w.Layout[0].Y.ValueInt64(),
+			Width:  w.Layout[0].Width.ValueInt64(),
+			Height: w.Layout[0].Height.ValueInt64(),
+		},
+	}
+}
+
+func newDashboardWidgetGraph(w mackerel.Widget) (DashboardWidgetGraph, error) {
+	if w.Type != dashboardWidgetTypeGraph {
+		return DashboardWidgetGraph{}, fmt.Errorf("expect graph widget, but got: %s", w.Type)
+	}
+
+	g := DashboardWidgetGraph{
+		dashboardWidget: newDashboardWidget(w),
+	}
+
+	switch w.Range.Type {
+	case dashboardRangeTypeAbsolute:
+		g.Range = []DashboardRange{{
+			Absolute: []DashboardRangeAbsolute{{
+				Start: types.Int64Value(w.Range.Start),
+				End:   types.Int64Value(w.Range.End),
+			}},
+		}}
+	case dashboardRangeTypeRelative:
+		g.Range = []DashboardRange{{
+			Relative: []DashboardRangeRelative{{
+				Period: types.Int64Value(w.Range.Period),
+				Offset: types.Int64Value(w.Range.Offset),
+			}},
+		}}
+	default:
+		return g, fmt.Errorf("unsupported range type: %s", w.Range.Type)
+	}
+
+	switch w.Graph.Type {
+	case dashboardGraphTypeHost:
+		g.Host = []DashboardGraphHost{{
+			HostID: types.StringValue(w.Graph.HostID),
+			Name:   types.StringValue(w.Graph.Name),
+		}}
+	case dashboardGraphTypeRole:
+		g.Role = []DashboardGraphRole{{
+			RoleFullname: types.StringValue(w.Graph.RoleFullName),
+			Name:         types.StringValue(w.Graph.Name),
+			IsStacked:    types.BoolValue(w.Graph.IsStacked),
+		}}
+	case dashboardGraphTypeService:
+		g.Service = []DashboardGraphService{{
+			ServiceName: types.StringValue(w.Graph.ServiceName),
+			Name:        types.StringValue(w.Graph.Name),
+		}}
+	case dashboardGraphTypeExpression:
+		g.Expression = []DashboardGraphExpression{{
+			Expression: types.StringValue(w.Graph.Expression),
+		}}
+	case dashboardGraphTypeQuery:
+		g.Query = []DashboardGraphQuery{{
+			Query:  types.StringValue(w.Graph.Query),
+			Legend: types.StringValue(w.Graph.Legend),
+		}}
+	default:
+		return g, fmt.Errorf("unsupported graph type: %s", w.Graph.Type)
+	}
+
+	return g, nil
+}
+
+func (g DashboardWidgetGraph) mackerelWidget() mackerel.Widget {
+	w := g.dashboardWidget.mackerelWidget()
+	w.Type = dashboardWidgetTypeGraph
+
+	if len(g.Range) != 1 {
+		panic(fmt.Sprintf("expect range length to be 1, but got: %d", len(g.Range)))
+	}
+	r := g.Range[0]
+	if len(g.Range[0].Absolute) == 1 {
+		w.Range = mackerel.Range{
+			Type:  dashboardRangeTypeAbsolute,
+			Start: r.Absolute[0].Start.ValueInt64(),
+			End:   r.Absolute[0].End.ValueInt64(),
+		}
+	} else if len(g.Range[0].Relative) == 1 {
+		w.Range = mackerel.Range{
+			Type:   dashboardRangeTypeRelative,
+			Period: r.Relative[0].Period.ValueInt64(),
+			Offset: r.Relative[0].Offset.ValueInt64(),
+		}
+	} else {
+		panic(fmt.Sprintf("invalid range: %+v", g.Range[0]))
+	}
+
+	if len(g.Host) == 1 {
+		w.Graph = mackerel.Graph{
+			Type:   dashboardGraphTypeHost,
+			HostID: g.Host[0].HostID.ValueString(),
+			Name:   g.Host[0].Name.ValueString(),
+		}
+	} else if len(g.Role) == 1 {
+		w.Graph = mackerel.Graph{
+			Type:         dashboardGraphTypeRole,
+			RoleFullName: g.Role[0].RoleFullname.ValueString(),
+			Name:         g.Role[0].Name.ValueString(),
+			IsStacked:    g.Role[0].IsStacked.ValueBool(),
+		}
+	} else if len(g.Service) == 1 {
+		w.Graph = mackerel.Graph{
+			Type:        dashboardGraphTypeService,
+			ServiceName: g.Service[0].ServiceName.ValueString(),
+			Name:        g.Service[0].Name.ValueString(),
+		}
+	} else if len(g.Expression) == 1 {
+		w.Graph = mackerel.Graph{
+			Type:       dashboardGraphTypeExpression,
+			Expression: g.Expression[0].Expression.ValueString(),
+		}
+	} else if len(g.Query) == 1 {
+		w.Graph = mackerel.Graph{
+			Type:   dashboardGraphTypeQuery,
+			Query:  g.Query[0].Query.ValueString(),
+			Legend: g.Query[0].Legend.ValueString(),
+		}
+	} else {
+		panic(fmt.Sprintf("invalid graph: %+v", g))
+	}
+
+	return w
+}
+
+func newDashboardWidgetValue(w mackerel.Widget) (DashboardWidgetValue, error) {
+	if w.Type != dashboardWidgetTypeValue {
+		return DashboardWidgetValue{}, fmt.Errorf("expect value widget, but got: %s", w.Type)
+	}
+	v := DashboardWidgetValue{
+		dashboardWidget: newDashboardWidget(w),
+		Metric:          []DashboardMetric{{}},
+		FractionSize:    types.Int64PointerValue(w.FractionSize),
+		Suffix:          types.StringValue(w.Suffix),
+	}
+	switch w.Metric.Type {
+	case dashboardMetricTypeHost:
+		v.Metric[0].Host = []DashboardMetricHost{{
+			HostID: types.StringValue(w.Metric.HostID),
+			Name:   types.StringValue(w.Metric.Name),
+		}}
+	case dashboardMetricTypeService:
+		v.Metric[0].Service = []DashboardMetricService{{
+			ServiceName: types.StringValue(w.Metric.ServiceName),
+			Name:        types.StringValue(w.Metric.Name),
+		}}
+	case dashboardMetricTypeExpression:
+		v.Metric[0].Expression = []DashboardMetricExpression{{
+			Expression: types.StringValue(w.Metric.Expression),
+		}}
+	case dashboardMetricTypeQuery:
+		v.Metric[0].Query = []DashboardMetricQuery{{
+			Query:  types.StringValue(w.Metric.Query),
+			Legend: types.StringValue(w.Metric.Legend),
+		}}
+	default:
+		return v, fmt.Errorf("unsupported metric type: %s", w.Metric.Type)
+	}
+	return v, nil
+}
+
+func (v DashboardWidgetValue) mackerelWidget() mackerel.Widget {
+	w := v.dashboardWidget.mackerelWidget()
+	w.Type = dashboardWidgetTypeValue
+	w.FractionSize = v.FractionSize.ValueInt64Pointer()
+	w.Suffix = v.Suffix.ValueString()
+
+	if len(v.Metric) != 1 {
+		panic(fmt.Sprintf("invalid metric length: %d", len(v.Metric)))
+	}
+	m := v.Metric[0]
+	if len(m.Host) == 1 {
+		w.Metric = mackerel.Metric{
+			Type:   dashboardMetricTypeHost,
+			HostID: m.Host[0].HostID.ValueString(),
+			Name:   m.Host[0].Name.ValueString(),
+		}
+	} else if len(m.Service) == 1 {
+		w.Metric = mackerel.Metric{
+			Type:        dashboardMetricTypeService,
+			ServiceName: m.Service[0].ServiceName.ValueString(),
+			Name:        m.Service[0].Name.ValueString(),
+		}
+	} else if len(m.Expression) == 1 {
+		w.Metric = mackerel.Metric{
+			Type:       dashboardMetricTypeExpression,
+			Expression: m.Expression[0].Expression.ValueString(),
+		}
+	} else if len(m.Query) == 1 {
+		w.Metric = mackerel.Metric{
+			Type:   dashboardMetricTypeQuery,
+			Query:  m.Query[0].Query.ValueString(),
+			Legend: m.Query[0].Legend.ValueString(),
+		}
+	} else {
+		panic(fmt.Sprintf("invalid metric: %+v", m))
+	}
+
+	return w
+}
+
+func newDashboardWidgetMarkdown(w mackerel.Widget) (DashboardWidgetMarkdown, error) {
+	if w.Type != dashboardWidgetTypeMarkdown {
+		return DashboardWidgetMarkdown{}, fmt.Errorf("expect markdown widget, but got: %s", w.Type)
+	}
+	return DashboardWidgetMarkdown{
+		dashboardWidget: newDashboardWidget(w),
+		Markdown:        types.StringValue(w.Markdown),
+	}, nil
+}
+
+func (m DashboardWidgetMarkdown) mackerelWidget() mackerel.Widget {
+	w := m.dashboardWidget.mackerelWidget()
+	w.Type = dashboardWidgetTypeMarkdown
+	w.Markdown = m.Markdown.ValueString()
+	return w
+}
+
+func newDashboardWidgetAlertStatus(w mackerel.Widget) (DashboardWidgetAlertStatus, error) {
+	if w.Type != dashboardWidgetTypeAlertStatus {
+		return DashboardWidgetAlertStatus{}, fmt.Errorf("expect alet status widget, but got: %s", w.Type)
+	}
+	return DashboardWidgetAlertStatus{
+		dashboardWidget: newDashboardWidget(w),
+		RoleFullname:    types.StringValue(w.RoleFullName),
+	}, nil
+}
+
+func (a DashboardWidgetAlertStatus) mackerelWidget() mackerel.Widget {
+	w := a.dashboardWidget.mackerelWidget()
+	w.Type = dashboardWidgetTypeAlertStatus
+	w.RoleFullName = a.RoleFullname.ValueString()
+	return w
+}

--- a/internal/mackerel/dashboard.go
+++ b/internal/mackerel/dashboard.go
@@ -199,6 +199,13 @@ func newDashboard(d mackerel.Dashboard) (DashboardModel, error) {
 	}
 
 	for _, w := range d.Widgets {
+		// unsupported features
+		if len(w.ReferenceLines) != 0 {
+			return m, fmt.Errorf("referenceLines is unsupported.")
+		}
+		if len(w.FormatRules) != 0 {
+			return m, fmt.Errorf("formatFules is unsupported.")
+		}
 		switch w.Type {
 		case dashboardWidgetTypeGraph:
 			wg, err := newDashboardWidgetGraph(w)

--- a/internal/mackerel/dashboard.go
+++ b/internal/mackerel/dashboard.go
@@ -29,13 +29,13 @@ type (
 		Width  types.Int64 `tfsdk:"width"`
 		Height types.Int64 `tfsdk:"height"`
 	}
-	dashboardWidget struct {
+	DashboardWidget struct {
 		Title  types.String      `tfsdk:"title"`
 		Layout []DashboardLayout `tfsdk:"layout"`
 	}
 
 	DashboardWidgetGraph struct {
-		dashboardWidget
+		DashboardWidget
 		Range []DashboardRange `tfsdk:"range"`
 
 		Host       []DashboardGraphHost       `tfsdk:"host"`
@@ -78,7 +78,7 @@ type (
 	}
 
 	DashboardWidgetValue struct {
-		dashboardWidget
+		DashboardWidget
 		Metric       []DashboardMetric `tfsdk:"metric"`
 		FractionSize types.Int64       `tfsdk:"fraction_size"`
 		Suffix       types.String      `tfsdk:"suffix"`
@@ -106,12 +106,12 @@ type (
 	}
 
 	DashboardWidgetMarkdown struct {
-		dashboardWidget
+		DashboardWidget
 		Markdown types.String `tfsdk:"markdown"`
 	}
 
 	DashboardWidgetAlertStatus struct {
-		dashboardWidget
+		DashboardWidget
 		RoleFullname types.String `tfsdk:"role_fullname"`
 	}
 )
@@ -257,8 +257,8 @@ func (d DashboardModel) mackerelDashboard() mackerel.Dashboard {
 	return md
 }
 
-func newDashboardWidget(w mackerel.Widget) dashboardWidget {
-	return dashboardWidget{
+func newDashboardWidget(w mackerel.Widget) DashboardWidget {
+	return DashboardWidget{
 		Title: types.StringValue(w.Title),
 		Layout: []DashboardLayout{{
 			X:      types.Int64Value(w.Layout.X),
@@ -269,7 +269,7 @@ func newDashboardWidget(w mackerel.Widget) dashboardWidget {
 	}
 }
 
-func (w dashboardWidget) mackerelWidget() mackerel.Widget {
+func (w DashboardWidget) mackerelWidget() mackerel.Widget {
 	return mackerel.Widget{
 		Title: w.Title.ValueString(),
 		Layout: mackerel.Layout{
@@ -287,7 +287,7 @@ func newDashboardWidgetGraph(w mackerel.Widget) (DashboardWidgetGraph, error) {
 	}
 
 	g := DashboardWidgetGraph{
-		dashboardWidget: newDashboardWidget(w),
+		DashboardWidget: newDashboardWidget(w),
 	}
 
 	switch w.Range.Type {
@@ -343,7 +343,7 @@ func newDashboardWidgetGraph(w mackerel.Widget) (DashboardWidgetGraph, error) {
 }
 
 func (g DashboardWidgetGraph) mackerelWidget() mackerel.Widget {
-	w := g.dashboardWidget.mackerelWidget()
+	w := g.DashboardWidget.mackerelWidget()
 	w.Type = dashboardWidgetTypeGraph
 
 	if len(g.Range) != 1 {
@@ -408,7 +408,7 @@ func newDashboardWidgetValue(w mackerel.Widget) (DashboardWidgetValue, error) {
 		return DashboardWidgetValue{}, fmt.Errorf("expect value widget, but got: %s", w.Type)
 	}
 	v := DashboardWidgetValue{
-		dashboardWidget: newDashboardWidget(w),
+		DashboardWidget: newDashboardWidget(w),
 		Metric:          []DashboardMetric{{}},
 		FractionSize:    types.Int64PointerValue(w.FractionSize),
 		Suffix:          types.StringValue(w.Suffix),
@@ -440,7 +440,7 @@ func newDashboardWidgetValue(w mackerel.Widget) (DashboardWidgetValue, error) {
 }
 
 func (v DashboardWidgetValue) mackerelWidget() mackerel.Widget {
-	w := v.dashboardWidget.mackerelWidget()
+	w := v.DashboardWidget.mackerelWidget()
 	w.Type = dashboardWidgetTypeValue
 	w.FractionSize = v.FractionSize.ValueInt64Pointer()
 	w.Suffix = v.Suffix.ValueString()
@@ -484,13 +484,13 @@ func newDashboardWidgetMarkdown(w mackerel.Widget) (DashboardWidgetMarkdown, err
 		return DashboardWidgetMarkdown{}, fmt.Errorf("expect markdown widget, but got: %s", w.Type)
 	}
 	return DashboardWidgetMarkdown{
-		dashboardWidget: newDashboardWidget(w),
+		DashboardWidget: newDashboardWidget(w),
 		Markdown:        types.StringValue(w.Markdown),
 	}, nil
 }
 
 func (m DashboardWidgetMarkdown) mackerelWidget() mackerel.Widget {
-	w := m.dashboardWidget.mackerelWidget()
+	w := m.DashboardWidget.mackerelWidget()
 	w.Type = dashboardWidgetTypeMarkdown
 	w.Markdown = m.Markdown.ValueString()
 	return w
@@ -501,13 +501,13 @@ func newDashboardWidgetAlertStatus(w mackerel.Widget) (DashboardWidgetAlertStatu
 		return DashboardWidgetAlertStatus{}, fmt.Errorf("expect alet status widget, but got: %s", w.Type)
 	}
 	return DashboardWidgetAlertStatus{
-		dashboardWidget: newDashboardWidget(w),
+		DashboardWidget: newDashboardWidget(w),
 		RoleFullname:    types.StringValue(w.RoleFullName),
 	}, nil
 }
 
 func (a DashboardWidgetAlertStatus) mackerelWidget() mackerel.Widget {
-	w := a.dashboardWidget.mackerelWidget()
+	w := a.DashboardWidget.mackerelWidget()
 	w.Type = dashboardWidgetTypeAlertStatus
 	w.RoleFullName = a.RoleFullname.ValueString()
 	return w

--- a/internal/mackerel/dashboard_test.go
+++ b/internal/mackerel/dashboard_test.go
@@ -1,0 +1,107 @@
+package mackerel
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+func Test_Dashboard_conv(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		api   mackerel.Dashboard
+		model DashboardModel
+	}{
+		"role graph": {
+			api: mackerel.Dashboard{
+				ID:      "2c5bLca8d",
+				Title:   "role graph dashboard title",
+				Memo:    "role graph dashboard",
+				URLPath: "role-graph-dashboard",
+				Widgets: []mackerel.Widget{{
+					Type:  "graph",
+					Title: "role graph",
+					Graph: mackerel.Graph{
+						Type:         "role",
+						RoleFullName: "service:role",
+						Name:         "loadavg5",
+						IsStacked:    true,
+					},
+					Range: mackerel.Range{
+						Type:   "relative",
+						Period: 3600,
+						Offset: 1800,
+					},
+					Layout: mackerel.Layout{
+						X:      2,
+						Y:      12,
+						Width:  10,
+						Height: 8,
+					},
+				}},
+				CreatedAt: 1439346145003,
+				UpdatedAt: 1439346145003,
+			},
+			model: DashboardModel{
+				ID:      types.StringValue("2c5bLca8d"),
+				Title:   types.StringValue("role graph dashboard title"),
+				Memo:    types.StringValue("role graph dashboard"),
+				URLPath: types.StringValue("role-graph-dashboard"),
+				Graph: []DashboardWidgetGraph{{
+					DashboardWidget: DashboardWidget{
+						Title: types.StringValue("role graph"),
+						Layout: []DashboardLayout{{
+							X:      types.Int64Value(2),
+							Y:      types.Int64Value(12),
+							Width:  types.Int64Value(10),
+							Height: types.Int64Value(8),
+						}},
+					},
+					Role: []DashboardGraphRole{{
+						RoleFullname: types.StringValue("service:role"),
+						Name:         types.StringValue("loadavg5"),
+						IsStacked:    types.BoolValue(true),
+					}},
+					Range: []DashboardRange{{
+						Relative: []DashboardRangeRelative{{
+							Period: types.Int64Value(3600),
+							Offset: types.Int64Value(1800),
+						}},
+					}},
+				}},
+				Value:       []DashboardWidgetValue{},
+				Markdown:    []DashboardWidgetMarkdown{},
+				AlertStatus: []DashboardWidgetAlertStatus{},
+				CreatedAt:   types.Int64Value(1439346145003),
+				UpdatedAt:   types.Int64Value(1439346145003),
+			},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name+"-toModel", func(t *testing.T) {
+			t.Parallel()
+
+			model, err := newDashboard(tt.api)
+			if err != nil {
+				t.Errorf("unexpected error: %+v", err)
+				return
+			}
+
+			if diff := cmp.Diff(model, tt.model); diff != "" {
+				t.Error(diff)
+			}
+		})
+		t.Run(name+"-toAPI", func(t *testing.T) {
+			t.Parallel()
+
+			api := tt.model.mackerelDashboard()
+			if diff := cmp.Diff(api, tt.api); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/internal/provider/data_source_mackerel_dashboard.go
+++ b/internal/provider/data_source_mackerel_dashboard.go
@@ -71,27 +71,35 @@ func schemaDashboardDataSource() schema.Schema {
 		},
 	}
 	return schema.Schema{
+		Description: "This data source allows access to details of a specific dashboard.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Required: true,
+				Description: schemaDashboardIDDesc,
+				Required:    true,
 			},
 			"title": schema.StringAttribute{
-				Computed: true,
+				Description: schemaDashboardTitleDesc,
+				Computed:    true,
 			},
 			"memo": schema.StringAttribute{
-				Computed: true,
+				Description: schemaDashboardMemoDesc,
+				Computed:    true,
 			},
 			"url_path": schema.StringAttribute{
-				Computed: true,
+				Description: schemaDashboardURLPathDesc,
+				Computed:    true,
 			},
 			"created_at": schema.Int64Attribute{
-				Computed: true,
+				Description: schemaDashboardCreatedAtDesc,
+				Computed:    true,
 			},
 			"updated_at": schema.Int64Attribute{
-				Computed: true,
+				Description: schemaDashboardUpdatedAtDesc,
+				Computed:    true,
 			},
 			"graph": schema.ListAttribute{
-				Computed: true,
+				Description: schemaDashboardGraphDesc,
+				Computed:    true,
 				ElementType: types.ObjectType{
 					AttrTypes: map[string]attr.Type{
 						"title":  types.StringType,
@@ -163,7 +171,8 @@ func schemaDashboardDataSource() schema.Schema {
 				},
 			},
 			"value": schema.ListAttribute{
-				Computed: true,
+				Description: schemaDashboardValueDesc,
+				Computed:    true,
 				ElementType: types.ObjectType{
 					AttrTypes: map[string]attr.Type{
 						"title":         types.StringType,
@@ -211,7 +220,8 @@ func schemaDashboardDataSource() schema.Schema {
 				},
 			},
 			"markdown": schema.ListAttribute{
-				Computed: true,
+				Description: schemaDashboardMarkdownDesc,
+				Computed:    true,
 				ElementType: types.ObjectType{
 					AttrTypes: map[string]attr.Type{
 						"title":    types.StringType,
@@ -221,7 +231,8 @@ func schemaDashboardDataSource() schema.Schema {
 				},
 			},
 			"alert_status": schema.ListAttribute{
-				Computed: true,
+				Description: schemaDashboardAlertStatusDesc,
+				Computed:    true,
 				ElementType: types.ObjectType{
 					AttrTypes: map[string]attr.Type{
 						"title":         types.StringType,

--- a/internal/provider/data_source_mackerel_dashboard.go
+++ b/internal/provider/data_source_mackerel_dashboard.go
@@ -1,0 +1,235 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel"
+)
+
+var (
+	_ datasource.DataSource              = (*mackerelDashboardDataSource)(nil)
+	_ datasource.DataSourceWithConfigure = (*mackerelDashboardDataSource)(nil)
+)
+
+type mackerelDashboardDataSource struct {
+	Client *mackerel.Client
+}
+
+func NewMackerelDashboardDataSource() datasource.DataSource {
+	return &mackerelDashboardDataSource{}
+}
+
+func (d *mackerelDashboardDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_dashboard"
+}
+
+func (d *mackerelDashboardDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schemaDashboardDataSource()
+}
+
+func (d *mackerelDashboardDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	client, diags := retrieveClient(ctx, req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+	d.Client = client
+}
+
+func (d *mackerelDashboardDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config mackerel.DashboardModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data, err := mackerel.ReadDashboard(ctx, d.Client, config.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to read a dashboard",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func schemaDashboardDataSource() schema.Schema {
+	layoutType := types.ListType{
+		ElemType: types.ObjectType{
+			AttrTypes: map[string]attr.Type{
+				"x":      types.Int64Type,
+				"y":      types.Int64Type,
+				"width":  types.Int64Type,
+				"height": types.Int64Type,
+			},
+		},
+	}
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Required: true,
+			},
+			"title": schema.StringAttribute{
+				Computed: true,
+			},
+			"memo": schema.StringAttribute{
+				Computed: true,
+			},
+			"url_path": schema.StringAttribute{
+				Computed: true,
+			},
+			"created_at": schema.Int64Attribute{
+				Computed: true,
+			},
+			"updated_at": schema.Int64Attribute{
+				Computed: true,
+			},
+			"graph": schema.ListAttribute{
+				Computed: true,
+				ElementType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"title":  types.StringType,
+						"layout": layoutType,
+						"range": types.ListType{
+							ElemType: types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"relative": types.ListType{
+										ElemType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"period": types.Int64Type,
+												"offset": types.Int64Type,
+											},
+										},
+									},
+									"absolute": types.ListType{
+										ElemType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"start": types.Int64Type,
+												"end":   types.Int64Type,
+											},
+										},
+									},
+								},
+							},
+						},
+
+						"host": types.ListType{
+							ElemType: types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"host_id": types.StringType,
+									"name":    types.StringType,
+								},
+							},
+						},
+						"role": types.ListType{
+							ElemType: types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"role_fullname": types.StringType,
+									"name":          types.StringType,
+									"is_stacked":    types.BoolType,
+								},
+							},
+						},
+						"service": types.ListType{
+							ElemType: types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"service_name": types.StringType,
+									"name":         types.StringType,
+								},
+							},
+						},
+						"expression": types.ListType{
+							ElemType: types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"expression": types.StringType,
+								},
+							},
+						},
+						"query": types.ListType{
+							ElemType: types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"query":  types.StringType,
+									"legend": types.StringType,
+								},
+							},
+						},
+					},
+				},
+			},
+			"value": schema.ListAttribute{
+				Computed: true,
+				ElementType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"title":         types.StringType,
+						"layout":        layoutType,
+						"fraction_size": types.Int64Type,
+						"suffix":        types.StringType,
+						"metric": types.ListType{
+							ElemType: types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"host": types.ListType{
+										ElemType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"host_id": types.StringType,
+												"name":    types.StringType,
+											},
+										},
+									},
+									"service": types.ListType{
+										ElemType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"service_name": types.StringType,
+												"name":         types.StringType,
+											},
+										},
+									},
+									"expression": types.ListType{
+										ElemType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"expression": types.StringType,
+											},
+										},
+									},
+									"query": types.ListType{
+										ElemType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"query":  types.StringType,
+												"legend": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"markdown": schema.ListAttribute{
+				Computed: true,
+				ElementType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"title":    types.StringType,
+						"layout":   layoutType,
+						"markdown": types.StringType,
+					},
+				},
+			},
+			"alert_status": schema.ListAttribute{
+				Computed: true,
+				ElementType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"title":         types.StringType,
+						"layout":        layoutType,
+						"role_fullname": types.StringType,
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/provider/data_source_mackerel_dashboard_test.go
+++ b/internal/provider/data_source_mackerel_dashboard_test.go
@@ -1,0 +1,25 @@
+package provider_test
+
+import (
+	"context"
+	"testing"
+
+	fwdatasource "github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider"
+)
+
+func Test_MackerelDashboardDataSource_schema(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	req := fwdatasource.SchemaRequest{}
+	resp := fwdatasource.SchemaResponse{}
+	if provider.NewMackerelDashboardDataSource().Schema(ctx, req, &resp); resp.Diagnostics.HasError() {
+		t.Fatalf("schema method diagnostics: %+v", resp.Diagnostics)
+	}
+
+	if diags := resp.Schema.ValidateImplementation(ctx); diags.HasError() {
+		t.Fatalf("schema validation diagnostics: %+v", diags)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -84,6 +84,7 @@ func (m *mackerelProvider) Configure(ctx context.Context, req provider.Configure
 func (m *mackerelProvider) Resources(context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewMackerelChannelResource,
+		NewMackerelDashboardResource,
 		NewMackerelMonitorResource,
 		NewMackerelNotificationGroupResource,
 		NewMackerelRoleResource,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -96,6 +96,7 @@ func (m *mackerelProvider) Resources(context.Context) []func() resource.Resource
 func (m *mackerelProvider) DataSources(context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
 		NewMackerelChannelDataSource,
+		NewMackerelDashboardDataSource,
 		NewMackerelMonitorDataSource,
 		NewMackerelNotificationGroupDataSource,
 		NewMackerelRoleDataSource,

--- a/internal/provider/resource_mackerel_dashboard.go
+++ b/internal/provider/resource_mackerel_dashboard.go
@@ -312,7 +312,6 @@ var schemaDashboardResource_graph = schema.ListNestedBlock{
 						path.MatchRelative(),
 						path.MatchRelative().AtParent().AtName("role"),
 						path.MatchRelative().AtParent().AtName("service"),
-						path.MatchRelative().AtParent().AtName("service"),
 						path.MatchRelative().AtParent().AtName("expression"),
 						path.MatchRelative().AtParent().AtName("query"),
 					),

--- a/internal/provider/resource_mackerel_dashboard.go
+++ b/internal/provider/resource_mackerel_dashboard.go
@@ -1,0 +1,576 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel"
+)
+
+var (
+	_ resource.Resource                = (*mackerelDashboardResource)(nil)
+	_ resource.ResourceWithConfigure   = (*mackerelDashboardResource)(nil)
+	_ resource.ResourceWithImportState = (*mackerelDashboardResource)(nil)
+)
+
+func NewMackerelDashboardResource() resource.Resource {
+	return &mackerelDashboardResource{}
+}
+
+type mackerelDashboardResource struct {
+	Client *mackerel.Client
+}
+
+func (r *mackerelDashboardResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_dashboard"
+}
+
+func (r *mackerelDashboardResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schemaDashboardResource()
+}
+
+func (r *mackerelDashboardResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	client, diags := retrieveClient(ctx, req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+	r.Client = client
+}
+
+func (r *mackerelDashboardResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data mackerel.DashboardModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Create(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to create a dashboard",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *mackerelDashboardResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data mackerel.DashboardModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Read(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to read a dashboard",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *mackerelDashboardResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data mackerel.DashboardModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Update(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to update a dashboard",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *mackerelDashboardResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data mackerel.DashboardModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Delete(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to delete a dashboard",
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *mackerelDashboardResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+const (
+	schemaDashboardIDDesc        = "The ID of the dashboard."
+	schemaDashboardTitleDesc     = "The name of the dashboard."
+	schemaDashboardMemoDesc      = "The notes regarding the dashboard."
+	schemaDashboardURLPathDesc   = "The URL path for the dashboard."
+	schemaDashboardCreatedAtDesc = "The time (in epoch seconds) at the dashboard created."
+	schemaDashboardUpdatedAtDesc = "The time (in epoch seconds) at the dashboard last updated."
+)
+
+func schemaDashboardResource() schema.Schema {
+	s := schema.Schema{
+		Description: "This resource allows creating and management of dashboards.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: schemaDashboardIDDesc,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"title": schema.StringAttribute{
+				Description: schemaDashboardTitleDesc,
+				Required:    true,
+			},
+			"memo": schema.StringAttribute{
+				Description: schemaDashboardMemoDesc,
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
+			},
+			"url_path": schema.StringAttribute{
+				Description: schemaDashboardURLPathDesc,
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
+			},
+			"created_at": schema.Int64Attribute{
+				Description: schemaDashboardCreatedAtDesc,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
+			},
+			"updated_at": schema.Int64Attribute{
+				Description: schemaDashboardUpdatedAtDesc,
+				Computed:    true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"graph":        schemaDashboardResource_graph,
+			"value":        schemaDashboardResource_value,
+			"markdown":     schemaDashboardResource_markdown,
+			"alert_status": schemaDashboardResource_alertStatus,
+		},
+	}
+	return s
+}
+
+const (
+	schemaDashboardWidget_titleDesc  = "The title of the widget."
+	schemaDashboardWidget_layoutDesc = "The layout of the widget."
+)
+
+var schemaDashboardResource_widgetTitle = schema.StringAttribute{
+	Description: schemaDashboardWidget_titleDesc,
+	Required:    true,
+}
+var schemaDashboardResource_widgetLayout = schema.ListNestedBlock{
+	Description: schemaDashboardWidget_layoutDesc,
+	Validators: []validator.List{
+		listvalidator.SizeBetween(1, 1), // Required
+	},
+	NestedObject: schema.NestedBlockObject{
+		Attributes: map[string]schema.Attribute{
+			"x": schema.Int64Attribute{
+				Required: true,
+			},
+			"y": schema.Int64Attribute{
+				Required: true,
+			},
+			"width": schema.Int64Attribute{
+				Required: true,
+			},
+			"height": schema.Int64Attribute{
+				Required: true,
+			},
+		},
+	},
+}
+
+const (
+	schemaDashboardGraph_rangeDesc               = "The graph display range."
+	schemaDashboardGraph_rangeRelativeDesc       = "The relative display range. From (current time + `offset` - `period`) to (current time + `offset`)."
+	schemaDashboardGraph_rangeRelativePeriodDesc = "The length of the period (in seconds)."
+	schemaDashboardGraph_rangeRelativeOffsetDesc = "The difference from the current time (in seconds)."
+	schemaDashboardGraph_rangeAbsoluteDesc       = "The absolute display range. From `start` to `end`."
+	schemaDashboardGraph_rangeAbsoluteStartDesc  = "The start time (in epoch seconds)."
+	schemaDashboardGraph_rangeAbsoluteEndDesc    = "The end time (in epoch seconds)."
+)
+
+var schemaDashboardResource_widgetRange = schema.ListNestedBlock{
+	Description: schemaDashboardGraph_rangeDesc,
+	Validators: []validator.List{
+		listvalidator.SizeAtMost(1), // Single Optional
+	},
+	NestedObject: schema.NestedBlockObject{
+		Validators: []validator.Object{},
+		Blocks: map[string]schema.Block{
+			"relative": schema.ListNestedBlock{
+				Description: schemaDashboardGraph_rangeRelativeDesc,
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+					listvalidator.ExactlyOneOf(
+						path.MatchRelative(),
+						path.MatchRelative().AtParent().AtName("absolute"),
+					),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"period": schema.Int64Attribute{
+							Description: schemaDashboardGraph_rangeRelativePeriodDesc,
+							Required:    true,
+						},
+						"offset": schema.Int64Attribute{
+							Description: schemaDashboardGraph_rangeRelativeOffsetDesc,
+							Required:    true,
+						},
+					},
+				},
+			},
+			"absolute": schema.ListNestedBlock{
+				Description: schemaDashboardGraph_rangeAbsoluteDesc,
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"start": schema.Int64Attribute{
+							Description: schemaDashboardGraph_rangeAbsoluteStartDesc,
+							Required:    true,
+						},
+						"end": schema.Int64Attribute{
+							Description: schemaDashboardGraph_rangeAbsoluteEndDesc,
+							Required:    true,
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+const (
+	schemaDashboardGraphDesc      = "The graph widget."
+	schemaDashboardGraph_nameDesc = "The name of the graph."
+
+	schemaDashboardGraph_hostDesc        = "The host graph."
+	schemaDashboardGraph_host_hostIDDesc = "The ID of the host."
+
+	schemaDashboardGraph_roleDesc              = "The role graph."
+	schemaDashboardGraph_role_roleFullNameDesc = "The service name or role ID."
+	schemaDashboardGraph_role_isStackedDesc    = "Whether the graph is stacked or line graph."
+
+	schemaDashboardGraph_serviceDesc             = "The service graph."
+	schemaDashboardGraph_service_serviceNameDesc = "The name of the service."
+
+	schemaDashboardGraph_expressionDesc            = "The expression graph."
+	schemaDashboardGraph_expression_expressionDesc = "The expression representing the graph."
+
+	schemaDashboardGraph_queryDesc        = "The query graph."
+	schemaDashboardGraph_query_queryDesc  = "The PromQL-style query."
+	schemaDashboardGraph_query_legendDesc = "The query legend."
+)
+
+var schemaDashboardResource_graph = schema.ListNestedBlock{
+	NestedObject: schema.NestedBlockObject{
+		Attributes: map[string]schema.Attribute{
+			"title": schemaDashboardResource_widgetTitle,
+		},
+		Blocks: map[string]schema.Block{
+			"range":  schemaDashboardResource_widgetRange,
+			"layout": schemaDashboardResource_widgetLayout,
+
+			"host": schema.ListNestedBlock{
+				Description: schemaDashboardGraph_hostDesc,
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+					listvalidator.ExactlyOneOf(
+						path.MatchRelative(),
+						path.MatchRelative().AtParent().AtName("role"),
+						path.MatchRelative().AtParent().AtName("service"),
+						path.MatchRelative().AtParent().AtName("service"),
+						path.MatchRelative().AtParent().AtName("expression"),
+						path.MatchRelative().AtParent().AtName("query"),
+					),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"host_id": schema.StringAttribute{
+							Description: schemaDashboardGraph_host_hostIDDesc,
+							Required:    true,
+						},
+						"name": schema.StringAttribute{
+							Description: schemaDashboardGraph_nameDesc,
+							Required:    true,
+						},
+					},
+				},
+			},
+			"role": schema.ListNestedBlock{
+				Description: schemaDashboardGraph_roleDesc,
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"role_fullname": schema.StringAttribute{
+							Description: schemaDashboardGraph_role_roleFullNameDesc,
+							Required:    true,
+						},
+						"name": schema.StringAttribute{
+							Description: schemaDashboardGraph_nameDesc,
+							Required:    true,
+						},
+						"is_stacked": schema.BoolAttribute{
+							Description: schemaDashboardGraph_role_isStackedDesc,
+							Optional:    true,
+							Computed:    true,
+							Default:     booldefault.StaticBool(false),
+						},
+					},
+				},
+			},
+			"service": schema.ListNestedBlock{
+				Description: schemaDashboardGraph_serviceDesc,
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"service_name": schema.StringAttribute{
+							Description: schemaDashboardGraph_service_serviceNameDesc,
+							Required:    true,
+						},
+						"name": schema.StringAttribute{
+							Description: schemaDashboardGraph_nameDesc,
+							Required:    true,
+						},
+					},
+				},
+			},
+			"expression": schema.ListNestedBlock{
+				Description: schemaDashboardGraph_expressionDesc,
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"expression": schema.StringAttribute{
+							Description: schemaDashboardGraph_expression_expressionDesc,
+							Required:    true,
+						},
+					},
+				},
+			},
+			"query": schema.ListNestedBlock{
+				Description: schemaDashboardGraph_queryDesc,
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"query": schema.StringAttribute{
+							Description: schemaDashboardGraph_query_queryDesc,
+							Required:    true,
+						},
+						"legend": schema.StringAttribute{
+							Description: schemaDashboardGraph_query_legendDesc,
+							Required:    true,
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+const (
+	schemaDashboardValueDesc              = "The value widget."
+	schemaDashboardValue_metricDesc       = "The metric configuration."
+	schemaDashboardValue_fractionSizeDesc = "The decimal places displayed on the widget (0-16)."
+	schemaDashboardValue_suffixDesc       = "The units to be displayed after the value."
+	schemaDashboardValue_nameDesc         = "The name of the metric."
+
+	schemaDashboardValue_hostDesc        = "The host metrics."
+	schemaDashboardValue_host_hostIDDesc = "The ID of the host."
+
+	schemaDashboardValue_serviceDesc             = "The service metrics."
+	schemaDashboardValue_service_serviceNameDesc = "The name of the service."
+
+	schemaDashboardValue_expressionDesc            = "The expression."
+	schemaDashboardValue_expression_expressionDesc = "The expression representing metrics."
+
+	schemaDashboardValue_queryDesc        = "The query."
+	schemaDashboardValue_query_queryDesc  = "The PromQL-style query representing metrics."
+	schemaDashboardValue_query_legendDesc = "The query legend."
+)
+
+var schemaDashboardResource_value = schema.ListNestedBlock{
+	Description: schemaDashboardValueDesc,
+	NestedObject: schema.NestedBlockObject{
+		Attributes: map[string]schema.Attribute{
+			"title": schemaDashboardResource_widgetTitle,
+			"fraction_size": schema.Int64Attribute{
+				Description: schemaDashboardValue_fractionSizeDesc,
+				Optional:    true,
+			},
+			"suffix": schema.StringAttribute{
+				Description: schemaDashboardValue_suffixDesc,
+				Required:    true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"layout": schemaDashboardResource_widgetLayout,
+			"metric": schema.ListNestedBlock{
+				Description: schemaDashboardValue_metricDesc,
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"host": schema.ListNestedBlock{
+							Description: schemaDashboardValue_hostDesc,
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+								listvalidator.ExactlyOneOf(
+									path.MatchRelative(),
+									path.MatchRelative().AtParent().AtName("service"),
+									path.MatchRelative().AtParent().AtName("expression"),
+									path.MatchRelative().AtParent().AtName("query"),
+								),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"host_id": schema.StringAttribute{
+										Description: schemaDashboardValue_host_hostIDDesc,
+										Required:    true,
+									},
+									"name": schema.StringAttribute{
+										Description: schemaDashboardValue_nameDesc,
+										Required:    true,
+									},
+								},
+							},
+						},
+						"service": schema.ListNestedBlock{
+							Description: schemaDashboardValue_serviceDesc,
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"service_name": schema.StringAttribute{
+										Description: schemaDashboardValue_service_serviceNameDesc,
+										Required:    true,
+									},
+									"name": schema.StringAttribute{
+										Description: schemaDashboardValue_nameDesc,
+										Required:    true,
+									},
+								},
+							},
+						},
+						"expression": schema.ListNestedBlock{
+							Description: schemaDashboardValue_expressionDesc,
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"expression": schema.StringAttribute{
+										Description: schemaDashboardValue_expression_expressionDesc,
+										Required:    true,
+									},
+								},
+							},
+						},
+						"query": schema.ListNestedBlock{
+							Description: schemaDashboardValue_queryDesc,
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"query": schema.StringAttribute{
+										Description: schemaDashboardValue_query_queryDesc,
+										Required:    true,
+									},
+									"legend": schema.StringAttribute{
+										Description: schemaDashboardValue_query_legendDesc,
+										Required:    true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+const (
+	schemaDashboardMarkdownDesc          = "The markdown widget."
+	schemaDashboardMarkdown_markdownDesc = "The markdown formatted string."
+)
+
+var schemaDashboardResource_markdown = schema.ListNestedBlock{
+	Description: schemaDashboardMarkdownDesc,
+	NestedObject: schema.NestedBlockObject{
+		Attributes: map[string]schema.Attribute{
+			"title": schemaDashboardResource_widgetTitle,
+			"markdown": schema.StringAttribute{
+				Description: schemaDashboardMarkdown_markdownDesc,
+				Required:    true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"layout": schemaDashboardResource_widgetLayout,
+		},
+	},
+}
+
+const (
+	schemaDashboardAlertStatusDesc              = "The alert status widget."
+	schemaDashboardAlertStatus_roleFullNameDesc = "The service name or role ID."
+)
+
+var schemaDashboardResource_alertStatus = schema.ListNestedBlock{
+	Description: schemaDashboardAlertStatusDesc,
+	NestedObject: schema.NestedBlockObject{
+		Attributes: map[string]schema.Attribute{
+			"title": schemaDashboardResource_widgetTitle,
+			"role_fullname": schema.StringAttribute{
+				Description: schemaDashboardAlertStatus_roleFullNameDesc,
+				Required:    true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"layout": schemaDashboardResource_widgetLayout,
+		},
+	},
+}

--- a/internal/provider/resource_mackerel_dashboard.go
+++ b/internal/provider/resource_mackerel_dashboard.go
@@ -180,8 +180,12 @@ func schemaDashboardResource() schema.Schema {
 }
 
 const (
-	schemaDashboardWidget_titleDesc  = "The title of the widget."
-	schemaDashboardWidget_layoutDesc = "The layout of the widget."
+	schemaDashboardWidget_titleDesc        = "The title of the widget."
+	schemaDashboardWidget_layoutDesc       = "The coordinates are specified with the upper left corner of the widget display area as the origin (x = 0, y = 0), with the x axis in the right direction and the y axis in the down direction as the positive direction."
+	schemaDashboardWidget_layoutXDesc      = "The x coordinate of the widget."
+	schemaDashboardWidget_layoutYDesc      = "The y coordinate of the widget."
+	schemaDashboardWidget_layoutWidthDesc  = "The width of the widget."
+	schemaDashboardWidget_layoutHeightDesc = "The height of the widget."
 )
 
 var schemaDashboardResource_widgetTitle = schema.StringAttribute{
@@ -196,16 +200,20 @@ var schemaDashboardResource_widgetLayout = schema.ListNestedBlock{
 	NestedObject: schema.NestedBlockObject{
 		Attributes: map[string]schema.Attribute{
 			"x": schema.Int64Attribute{
-				Required: true,
+				Description: schemaDashboardWidget_layoutXDesc,
+				Required:    true,
 			},
 			"y": schema.Int64Attribute{
-				Required: true,
+				Description: schemaDashboardWidget_layoutYDesc,
+				Required:    true,
 			},
 			"width": schema.Int64Attribute{
-				Required: true,
+				Description: schemaDashboardWidget_layoutWidthDesc,
+				Required:    true,
 			},
 			"height": schema.Int64Attribute{
-				Required: true,
+				Description: schemaDashboardWidget_layoutHeightDesc,
+				Required:    true,
 			},
 		},
 	},

--- a/internal/provider/resource_mackerel_dashboard_test.go
+++ b/internal/provider/resource_mackerel_dashboard_test.go
@@ -1,0 +1,25 @@
+package provider_test
+
+import (
+	"context"
+	"testing"
+
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider"
+)
+
+func Test_MackerelDashboardResource_schema(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	req := fwresource.SchemaRequest{}
+	resp := fwresource.SchemaResponse{}
+	if provider.NewMackerelDashboardResource().Schema(ctx, req, &resp); resp.Diagnostics.HasError() {
+		t.Fatalf("schema method diagnostics: %+v", resp.Diagnostics)
+	}
+
+	if diags := resp.Schema.ValidateImplementation(ctx); diags.HasError() {
+		t.Fatalf("schema validation diagnostics: %+v", diags)
+	}
+}

--- a/mackerel/provider.go
+++ b/mackerel/provider.go
@@ -92,6 +92,7 @@ func protoV5ProviderServer(provider *schema.Provider) tfprotov5.ProviderServer {
 
 		// Data Sources
 		delete(provider.DataSourcesMap, "mackerel_channel")
+		delete(provider.DataSourcesMap, "mackerel_dashboard")
 		delete(provider.DataSourcesMap, "mackerel_monitor")
 		delete(provider.DataSourcesMap, "mackerel_notification_group")
 		delete(provider.DataSourcesMap, "mackerel_role")

--- a/mackerel/provider.go
+++ b/mackerel/provider.go
@@ -83,6 +83,7 @@ func protoV5ProviderServer(provider *schema.Provider) tfprotov5.ProviderServer {
 
 		// Resources
 		delete(provider.ResourcesMap, "mackerel_channel")
+		delete(provider.ResourcesMap, "mackerel_dashboard")
 		delete(provider.ResourcesMap, "mackerel_monitor")
 		delete(provider.ResourcesMap, "mackerel_notification_group")
 		delete(provider.ResourcesMap, "mackerel_role")


### PR DESCRIPTION
Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ MACKEREL_EXPERIMENTAL_TFFRAMEWORK=1 make testacc TESTS='"Acc(DataSource)?MackerelDashboard"'
TF_ACC=1 go test -v ./mackerel/... -run "Acc(DataSource)?MackerelDashboard" -timeout 120m                                                                                                          2024/09/06 12:50:53 [INFO] mackerel: use terraform-plugin-framework based implementation
=== RUN   TestAccDataSourceMackerelDashboardGraph
=== PAUSE TestAccDataSourceMackerelDashboardGraph
=== RUN   TestAccDataSourceMackerelDashboardValue
=== PAUSE TestAccDataSourceMackerelDashboardValue
=== RUN   TestAccDataSourceMackerelDashboardMarkdown
=== PAUSE TestAccDataSourceMackerelDashboardMarkdown
=== RUN   TestAccDataSourceMackerelDashboardAlertStatus
=== PAUSE TestAccDataSourceMackerelDashboardAlertStatus
=== RUN   TestAccMackerelDashboardGraph
=== PAUSE TestAccMackerelDashboardGraph
=== RUN   TestAccMackerelDashboardValue
=== PAUSE TestAccMackerelDashboardValue
=== RUN   TestAccMackerelDashboardMarkdown
=== PAUSE TestAccMackerelDashboardMarkdown
=== RUN   TestAccMackerelDashboardAlertStatus
=== PAUSE TestAccMackerelDashboardAlertStatus
=== CONT  TestAccDataSourceMackerelDashboardGraph
=== CONT  TestAccMackerelDashboardMarkdown
=== CONT  TestAccDataSourceMackerelDashboardAlertStatus
=== CONT  TestAccDataSourceMackerelDashboardMarkdown
=== CONT  TestAccMackerelDashboardAlertStatus
=== CONT  TestAccMackerelDashboardValue
=== CONT  TestAccMackerelDashboardGraph
=== CONT  TestAccDataSourceMackerelDashboardValue
--- PASS: TestAccDataSourceMackerelDashboardMarkdown (13.84s)
--- PASS: TestAccDataSourceMackerelDashboardAlertStatus (13.85s)
--- PASS: TestAccDataSourceMackerelDashboardGraph (14.78s)
--- PASS: TestAccDataSourceMackerelDashboardValue (18.29s)
--- PASS: TestAccMackerelDashboardMarkdown (19.34s)
--- PASS: TestAccMackerelDashboardValue (19.96s)
--- PASS: TestAccMackerelDashboardAlertStatus (20.02s)
--- PASS: TestAccMackerelDashboardGraph (20.50s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel 21.649s
```
