### PR TITLE
Reimplement downtime with terraform-plugin-framework

### DIFF
--- a/internal/mackerel/downtime.go
+++ b/internal/mackerel/downtime.go
@@ -18,7 +18,7 @@ type DowntimeModel struct {
 	Duration             types.Int64          `tfsdk:"duration"`
 	Recurrence           []DowntimeRecurrence `tfsdk:"recurrence"` // length <= 1
 	ServiceScopes        []string             `tfsdk:"service_scopes"`
-	SerciceExcludeScopes []string             `tfsdk:"service_exclude_scopes"`
+	ServiceExcludeScopes []string             `tfsdk:"service_exclude_scopes"`
 	RoleScopes           []string             `tfsdk:"role_scopes"`
 	RoleExcludeScopes    []string             `tfsdk:"role_exclude_scopes"`
 	MonitorScopes        []string             `tfsdk:"monitor_scopes"`
@@ -96,7 +96,7 @@ func newDowntime(d mackerel.Downtime) *DowntimeModel {
 		Start:                types.Int64Value(d.Start),
 		Duration:             types.Int64Value(d.Duration),
 		ServiceScopes:        d.ServiceScopes,
-		SerciceExcludeScopes: d.ServiceExcludeScopes,
+		ServiceExcludeScopes: d.ServiceExcludeScopes,
 		RoleScopes:           d.RoleScopes,
 		RoleExcludeScopes:    d.RoleExcludeScopes,
 		MonitorScopes:        d.MonitorScopes,
@@ -143,7 +143,7 @@ func (d *DowntimeModel) mackerelDowntime() *mackerel.Downtime {
 		Start:                d.Start.ValueInt64(),
 		Duration:             d.Duration.ValueInt64(),
 		ServiceScopes:        d.ServiceScopes,
-		ServiceExcludeScopes: d.SerciceExcludeScopes,
+		ServiceExcludeScopes: d.ServiceExcludeScopes,
 		RoleScopes:           d.RoleScopes,
 		RoleExcludeScopes:    d.RoleExcludeScopes,
 		MonitorScopes:        d.MonitorScopes,
@@ -179,11 +179,16 @@ func (d *DowntimeModel) mackerelDowntime() *mackerel.Downtime {
 }
 
 func (d *DowntimeModel) merge(newModel DowntimeModel) {
+	// preserve nil
+	if len(d.Recurrence) == 1 && len(d.Recurrence[0].Weekdays) == 0 &&
+		len(newModel.Recurrence) == 1 && len(newModel.Recurrence[0].Weekdays) == 0 {
+		newModel.Recurrence[0].Weekdays = d.Recurrence[0].Weekdays
+	}
 	if len(d.ServiceScopes) == 0 && len(newModel.ServiceScopes) == 0 {
 		newModel.ServiceScopes = d.ServiceScopes
 	}
-	if len(d.SerciceExcludeScopes) == 0 && len(newModel.SerciceExcludeScopes) == 0 {
-		newModel.SerciceExcludeScopes = d.SerciceExcludeScopes
+	if len(d.ServiceExcludeScopes) == 0 && len(newModel.ServiceExcludeScopes) == 0 {
+		newModel.ServiceExcludeScopes = d.ServiceExcludeScopes
 	}
 	if len(d.RoleScopes) == 0 && len(newModel.RoleScopes) == 0 {
 		newModel.RoleScopes = d.RoleScopes

--- a/internal/mackerel/downtime.go
+++ b/internal/mackerel/downtime.go
@@ -1,0 +1,201 @@
+package mackerel
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+type DowntimeModel struct {
+	ID                   types.String         `tfsdk:"id"`
+	Name                 types.String         `tfsdk:"name"`
+	Memo                 types.String         `tfsdk:"memo"`
+	Start                types.Int64          `tfsdk:"start"`
+	Duration             types.Int64          `tfsdk:"duration"`
+	Recurrence           []DowntimeRecurrence `tfsdk:"recurrence"` // length <= 1
+	ServiceScopes        []string             `tfsdk:"service_scopes"`
+	SerciceExcludeScopes []string             `tfsdk:"service_exclude_scopes"`
+	RoleScopes           []string             `tfsdk:"role_scopes"`
+	RoleExcludeScopes    []string             `tfsdk:"role_exclude_scopes"`
+	MonitorScopes        []string             `tfsdk:"monitor_scopes"`
+	MonitorExcludeScopes []string             `tfsdk:"monitor_exclude_scopes"`
+}
+type DowntimeRecurrence struct {
+	Type     types.String `tfsdk:"type"`
+	Interval types.Int64  `tfsdk:"interval"`
+	Weekdays []string     `tfsdk:"weekdays"`
+	Until    types.Int64  `tfsdk:"until"`
+}
+
+func ReadDowntime(_ context.Context, client *Client, id string) (*DowntimeModel, error) {
+	return readDowntime(client, id)
+}
+
+type downtimeFinder interface {
+	FindDowntimes() ([]*mackerel.Downtime, error)
+}
+
+func readDowntime(client downtimeFinder, id string) (*DowntimeModel, error) {
+	downtimes, err := client.FindDowntimes()
+	if err != nil {
+		return nil, err
+	}
+
+	downtimeIdx := slices.IndexFunc(downtimes, func(d *mackerel.Downtime) bool {
+		return d.ID == id
+	})
+	if downtimeIdx < 0 {
+		return nil, fmt.Errorf("the ID '%s' does not match any downtime in mackerel.io", id)
+	}
+
+	return newDowntime(*downtimes[downtimeIdx]), nil
+}
+
+func (d *DowntimeModel) Create(_ context.Context, client *Client) error {
+	createdDowntime, err := client.CreateDowntime(d.mackerelDowntime())
+	if err != nil {
+		return err
+	}
+
+	d.ID = types.StringValue(createdDowntime.ID)
+	return nil
+}
+
+func (d *DowntimeModel) Read(_ context.Context, client *Client) error {
+	newModel, err := readDowntime(client, d.ID.ValueString())
+	if err != nil {
+		return err
+	}
+	d.merge(*newModel)
+	return nil
+}
+
+func (d *DowntimeModel) Update(_ context.Context, client *Client) error {
+	if _, err := client.UpdateDowntime(d.ID.ValueString(), d.mackerelDowntime()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *DowntimeModel) Delete(_ context.Context, client *Client) error {
+	if _, err := client.DeleteDowntime(d.ID.ValueString()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func newDowntime(d mackerel.Downtime) *DowntimeModel {
+	model := &DowntimeModel{
+		ID:                   types.StringValue(d.ID),
+		Name:                 types.StringValue(d.Name),
+		Memo:                 types.StringValue(d.Memo),
+		Start:                types.Int64Value(d.Start),
+		Duration:             types.Int64Value(d.Duration),
+		ServiceScopes:        d.ServiceScopes,
+		SerciceExcludeScopes: d.ServiceExcludeScopes,
+		RoleScopes:           d.RoleScopes,
+		RoleExcludeScopes:    d.RoleExcludeScopes,
+		MonitorScopes:        d.MonitorScopes,
+		MonitorExcludeScopes: d.MonitorExcludeScopes,
+	}
+	if d.Recurrence != nil {
+		recurrence := DowntimeRecurrence{
+			Type:     types.StringValue(d.Recurrence.Type.String()),
+			Interval: types.Int64Value(d.Recurrence.Interval),
+			Until:    types.Int64Value(d.Recurrence.Until),
+		}
+		recurrence.Weekdays = make([]string, 0, len(d.Recurrence.Weekdays))
+		for _, wd := range d.Recurrence.Weekdays {
+			recurrence.Weekdays = append(recurrence.Weekdays, wd.String())
+		}
+		model.Recurrence = []DowntimeRecurrence{recurrence}
+	}
+	return model
+}
+
+var stringsToMackerelRecurrenceType = map[string]mackerel.DowntimeRecurrenceType{
+	"hourly":  mackerel.DowntimeRecurrenceTypeHourly,
+	"daily":   mackerel.DowntimeRecurrenceTypeDaily,
+	"weekly":  mackerel.DowntimeRecurrenceTypeWeekly,
+	"monthly": mackerel.DowntimeRecurrenceTypeMonthly,
+	"yearly":  mackerel.DowntimeRecurrenceTypeYearly,
+}
+
+var stringToMackerelWeekday = map[string]mackerel.DowntimeWeekday{
+	"Sunday":    mackerel.DowntimeWeekday(time.Sunday),
+	"Monday":    mackerel.DowntimeWeekday(time.Monday),
+	"Tuesday":   mackerel.DowntimeWeekday(time.Tuesday),
+	"Wednesday": mackerel.DowntimeWeekday(time.Wednesday),
+	"Thursday":  mackerel.DowntimeWeekday(time.Thursday),
+	"Friday":    mackerel.DowntimeWeekday(time.Friday),
+	"Saturday":  mackerel.DowntimeWeekday(time.Saturday),
+}
+
+func (d *DowntimeModel) mackerelDowntime() *mackerel.Downtime {
+	mackerelDowntime := &mackerel.Downtime{
+		ID:                   d.ID.ValueString(),
+		Name:                 d.Name.ValueString(),
+		Memo:                 d.Memo.ValueString(),
+		Start:                d.Start.ValueInt64(),
+		Duration:             d.Duration.ValueInt64(),
+		ServiceScopes:        d.ServiceScopes,
+		ServiceExcludeScopes: d.SerciceExcludeScopes,
+		RoleScopes:           d.RoleScopes,
+		RoleExcludeScopes:    d.RoleExcludeScopes,
+		MonitorScopes:        d.MonitorScopes,
+		MonitorExcludeScopes: d.MonitorExcludeScopes,
+	}
+	if len(d.Recurrence) == 1 {
+		recurrence := d.Recurrence[0]
+
+		recurrenceType, ok := stringsToMackerelRecurrenceType[recurrence.Type.ValueString()]
+		if !ok {
+			panic(fmt.Errorf("invalid recurrence type: %v", recurrence.Type))
+		}
+
+		mackerelWeekdays := make([]mackerel.DowntimeWeekday, 0, len(recurrence.Weekdays))
+		for _, weekday := range recurrence.Weekdays {
+			mackerelWeekday, ok := stringToMackerelWeekday[weekday]
+			if !ok {
+				panic(fmt.Errorf("invalid weekday: %s", weekday))
+			}
+			mackerelWeekdays = append(mackerelWeekdays, mackerelWeekday)
+		}
+
+		mackerelRecurrence := &mackerel.DowntimeRecurrence{
+			Type:     recurrenceType,
+			Interval: recurrence.Interval.ValueInt64(),
+			Weekdays: mackerelWeekdays,
+			Until:    recurrence.Until.ValueInt64(),
+		}
+		mackerelDowntime.Recurrence = mackerelRecurrence
+
+	}
+	return mackerelDowntime
+}
+
+func (d *DowntimeModel) merge(newModel DowntimeModel) {
+	if len(d.ServiceScopes) == 0 && len(newModel.ServiceScopes) == 0 {
+		newModel.ServiceScopes = d.ServiceScopes
+	}
+	if len(d.SerciceExcludeScopes) == 0 && len(newModel.SerciceExcludeScopes) == 0 {
+		newModel.SerciceExcludeScopes = d.SerciceExcludeScopes
+	}
+	if len(d.RoleScopes) == 0 && len(newModel.RoleScopes) == 0 {
+		newModel.RoleScopes = d.RoleScopes
+	}
+	if len(d.RoleExcludeScopes) == 0 && len(newModel.RoleExcludeScopes) == 0 {
+		newModel.RoleExcludeScopes = d.RoleExcludeScopes
+	}
+	if len(d.MonitorScopes) == 0 && len(newModel.MonitorScopes) == 0 {
+		newModel.MonitorScopes = d.MonitorScopes
+	}
+	if len(d.MonitorExcludeScopes) == 0 && len(newModel.MonitorExcludeScopes) == 0 {
+		newModel.MonitorExcludeScopes = d.MonitorExcludeScopes
+	}
+	*d = newModel
+}

--- a/internal/mackerel/downtime_test.go
+++ b/internal/mackerel/downtime_test.go
@@ -1,0 +1,267 @@
+package mackerel
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+func Test_Downtime_ReadDowntime(t *testing.T) {
+	t.Parallel()
+
+	defaultClient := func() ([]*mackerel.Downtime, error) {
+		return []*mackerel.Downtime{
+			{
+				ID:       "5ghjb6vgDFN",
+				Name:     "basic",
+				Start:    1735707600,
+				Duration: 3600,
+			},
+			{
+				ID:       "5ghjbbVABY5",
+				Name:     "full",
+				Memo:     "This downtime is managed by Terraform.",
+				Start:    1735707600,
+				Duration: 3600,
+				Recurrence: &mackerel.DowntimeRecurrence{
+					Type:     mackerel.DowntimeRecurrenceTypeWeekly,
+					Interval: 2,
+					Weekdays: []mackerel.DowntimeWeekday{
+						mackerel.DowntimeWeekday(time.Wednesday),
+						mackerel.DowntimeWeekday(time.Thursday),
+					},
+					Until: 1767193199,
+				},
+				ServiceScopes:        []string{"include-svc"},
+				ServiceExcludeScopes: []string{"exclude-svc"},
+				RoleScopes:           []string{"svc: include-role"},
+				RoleExcludeScopes:    []string{"svc: exclude-role"},
+				MonitorScopes:        []string{"5ghjb7CrJ43"},
+				MonitorExcludeScopes: []string{"5ghjbaziveA"},
+			},
+		}, nil
+	}
+
+	cases := map[string]struct {
+		inClient downtimeFinderFunc
+		inID     string
+
+		wants   DowntimeModel
+		wantErr bool
+	}{
+		"basic": {
+			inClient: defaultClient,
+			inID:     "5ghjb6vgDFN",
+
+			wants: DowntimeModel{
+				ID:       types.StringValue("5ghjb6vgDFN"),
+				Name:     types.StringValue("basic"),
+				Memo:     types.StringValue(""),
+				Start:    types.Int64Value(1735707600),
+				Duration: types.Int64Value(3600),
+			},
+		},
+		"no downtime": {
+			inClient: defaultClient,
+			inID:     "nonexist",
+
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			model, err := readDowntime(tt.inClient, tt.inID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("unexpected error: %+v", err)
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(*model, tt.wants); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+type downtimeFinderFunc func() ([]*mackerel.Downtime, error)
+
+func (f downtimeFinderFunc) FindDowntimes() ([]*mackerel.Downtime, error) {
+	return f()
+}
+
+func Test_Downtime_conv(t *testing.T) {
+	t.Parallel()
+
+	// api <-> model
+	cases := map[string]struct {
+		api   mackerel.Downtime
+		model DowntimeModel
+	}{
+		"basic": {
+			api: mackerel.Downtime{
+				ID:       "5ghjb6vgDFN",
+				Name:     "basic",
+				Start:    1735707600,
+				Duration: 3600,
+			},
+			model: DowntimeModel{
+				ID:       types.StringValue("5ghjb6vgDFN"),
+				Name:     types.StringValue("basic"),
+				Memo:     types.StringValue(""),
+				Start:    types.Int64Value(1735707600),
+				Duration: types.Int64Value(3600),
+			},
+		},
+		"full": {
+			api: mackerel.Downtime{
+				ID:       "5ghjbbVABY5",
+				Name:     "full",
+				Memo:     "This downtime is managed by Terraform.",
+				Start:    1735707600,
+				Duration: 3600,
+				Recurrence: &mackerel.DowntimeRecurrence{
+					Type:     mackerel.DowntimeRecurrenceTypeWeekly,
+					Interval: 2,
+					Weekdays: []mackerel.DowntimeWeekday{
+						mackerel.DowntimeWeekday(time.Wednesday),
+						mackerel.DowntimeWeekday(time.Thursday),
+					},
+					Until: 1767193199,
+				},
+				ServiceScopes:        []string{"include-svc"},
+				ServiceExcludeScopes: []string{"exclude-svc"},
+				RoleScopes:           []string{"svc: include-role"},
+				RoleExcludeScopes:    []string{"svc: exclude-role"},
+				MonitorScopes:        []string{"5ghjb7CrJ43"},
+				MonitorExcludeScopes: []string{"5ghjbaziveA"},
+			},
+			model: DowntimeModel{
+				ID:       types.StringValue("5ghjbbVABY5"),
+				Name:     types.StringValue("full"),
+				Memo:     types.StringValue("This downtime is managed by Terraform."),
+				Start:    types.Int64Value(1735707600),
+				Duration: types.Int64Value(3600),
+				Recurrence: []DowntimeRecurrence{{
+					Type:     types.StringValue("weekly"),
+					Interval: types.Int64Value(2),
+					Weekdays: []string{"Wednesday", "Thursday"},
+					Until:    types.Int64Value(1767193199),
+				}},
+				ServiceScopes:        []string{"include-svc"},
+				ServiceExcludeScopes: []string{"exclude-svc"},
+				RoleScopes:           []string{"svc: include-role"},
+				RoleExcludeScopes:    []string{"svc: exclude-role"},
+				MonitorScopes:        []string{"5ghjb7CrJ43"},
+				MonitorExcludeScopes: []string{"5ghjbaziveA"},
+			},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name+"/fromAPI", func(t *testing.T) {
+			t.Parallel()
+
+			model := newDowntime(tt.api)
+			if diff := cmp.Diff(*model, tt.model); diff != "" {
+				t.Error(diff)
+			}
+		})
+		t.Run(name+"/toAPI", func(t *testing.T) {
+			t.Parallel()
+
+			api := tt.model.mackerelDowntime()
+			if diff := cmp.Diff(*api, tt.api); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func Test_Downtime_merge(t *testing.T) {
+	t.Parallel()
+
+	// in <- inNew == wants
+	cases := map[string]struct {
+		in    DowntimeModel
+		inNew DowntimeModel
+		wants DowntimeModel
+	}{
+		"basic": {
+			in: DowntimeModel{
+				ID:       types.StringValue("5ghjb6vgDFN"),
+				Name:     types.StringValue("basic"),
+				Memo:     types.StringValue(""),
+				Start:    types.Int64Value(1735707600),
+				Duration: types.Int64Value(3600),
+				Recurrence: []DowntimeRecurrence{{
+					Type:     types.StringValue("weekly"),
+					Interval: types.Int64Value(2),
+					Weekdays: nil,
+					Until:    types.Int64Value(1767193199),
+				}},
+				ServiceScopes:        nil,
+				ServiceExcludeScopes: nil,
+				RoleScopes:           nil,
+				RoleExcludeScopes:    nil,
+				MonitorScopes:        nil,
+				MonitorExcludeScopes: []string{},
+			},
+			inNew: DowntimeModel{
+				ID:       types.StringValue("5ghjb6vgDFN"),
+				Name:     types.StringValue("basic"),
+				Memo:     types.StringValue("memo"), // changed
+				Start:    types.Int64Value(1735707600),
+				Duration: types.Int64Value(3600),
+				Recurrence: []DowntimeRecurrence{{
+					Type:     types.StringValue("weekly"),
+					Interval: types.Int64Value(2),
+					Weekdays: []string{},
+					Until:    types.Int64Value(1767193199),
+				}},
+				ServiceScopes:        []string{},
+				ServiceExcludeScopes: []string{},
+				RoleScopes:           []string{},
+				RoleExcludeScopes:    []string{},
+				MonitorScopes:        []string{},
+				MonitorExcludeScopes: nil,
+			},
+			wants: DowntimeModel{
+				ID:       types.StringValue("5ghjb6vgDFN"),
+				Name:     types.StringValue("basic"),
+				Memo:     types.StringValue("memo"), // changed
+				Start:    types.Int64Value(1735707600),
+				Duration: types.Int64Value(3600),
+				Recurrence: []DowntimeRecurrence{{
+					Type:     types.StringValue("weekly"),
+					Interval: types.Int64Value(2),
+					Weekdays: nil,
+					Until:    types.Int64Value(1767193199),
+				}},
+				ServiceScopes:        nil,
+				ServiceExcludeScopes: nil,
+				RoleScopes:           nil,
+				RoleExcludeScopes:    nil,
+				MonitorScopes:        nil,
+				MonitorExcludeScopes: []string{},
+			},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.in.merge(tt.inNew)
+			if diff := cmp.Diff(tt.in, tt.wants); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/internal/provider/data_source_mackerel_downtime.go
+++ b/internal/provider/data_source_mackerel_downtime.go
@@ -1,0 +1,120 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel"
+)
+
+var (
+	_ datasource.DataSource              = (*mackerelDowntimeDataSource)(nil)
+	_ datasource.DataSourceWithConfigure = (*mackerelDowntimeDataSource)(nil)
+)
+
+func NewMackerelDowntimeDataSource() datasource.DataSource {
+	return &mackerelDowntimeDataSource{}
+}
+
+type mackerelDowntimeDataSource struct {
+	Client *mackerel.Client
+}
+
+func (d *mackerelDowntimeDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_downtime"
+}
+
+func (d *mackerelDowntimeDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schemaDowntimeDataSource()
+}
+
+func (d *mackerelDowntimeDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	client, diags := retrieveClient(ctx, req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+	d.Client = client
+}
+
+func (d *mackerelDowntimeDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config mackerel.DowntimeModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data, err := mackerel.ReadDowntime(ctx, d.Client, config.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to read a downtime",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func schemaDowntimeDataSource() schema.Schema {
+	s := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Required: true,
+			},
+			"name": schema.StringAttribute{
+				Computed: true,
+			},
+			"memo": schema.StringAttribute{
+				Computed: true,
+			},
+			"start": schema.Int64Attribute{
+				Computed: true,
+			},
+			"duration": schema.Int64Attribute{
+				Computed: true,
+			},
+			"recurrence": schema.ListAttribute{
+				Computed: true,
+				ElementType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"type":     types.StringType,
+						"interval": types.Int64Type,
+						"weekdays": types.SetType{
+							ElemType: types.StringType,
+						},
+						"until": types.Int64Type,
+					},
+				},
+			},
+			"service_scopes": schema.SetAttribute{
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+			"service_exclude_scopes": schema.SetAttribute{
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+			"role_scopes": schema.SetAttribute{
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+			"role_exclude_scopes": schema.SetAttribute{
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+			"monitor_scopes": schema.SetAttribute{
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+			"monitor_exclude_scopes": schema.SetAttribute{
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+		},
+	}
+	return s
+}

--- a/internal/provider/data_source_mackerel_downtime.go
+++ b/internal/provider/data_source_mackerel_downtime.go
@@ -61,24 +61,31 @@ func (d *mackerelDowntimeDataSource) Read(ctx context.Context, req datasource.Re
 
 func schemaDowntimeDataSource() schema.Schema {
 	s := schema.Schema{
+		Description: "This data source allows access to details of a specific downtime setting.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Required: true,
+				Description: schemaDowntimeIDDesc,
+				Required:    true,
 			},
 			"name": schema.StringAttribute{
-				Computed: true,
+				Description: schemaDowntimeNameDesc,
+				Computed:    true,
 			},
 			"memo": schema.StringAttribute{
-				Computed: true,
+				Description: schemaDowntimeMemoDesc,
+				Computed:    true,
 			},
 			"start": schema.Int64Attribute{
-				Computed: true,
+				Description: schemaDowntimeStartDesc,
+				Computed:    true,
 			},
 			"duration": schema.Int64Attribute{
-				Computed: true,
+				Description: schemaDowntimeDurationDesc,
+				Computed:    true,
 			},
 			"recurrence": schema.ListAttribute{
-				Computed: true,
+				Description: schemaDowntimeRecurrenceDesc,
+				Computed:    true,
 				ElementType: types.ObjectType{
 					AttrTypes: map[string]attr.Type{
 						"type":     types.StringType,
@@ -91,26 +98,32 @@ func schemaDowntimeDataSource() schema.Schema {
 				},
 			},
 			"service_scopes": schema.SetAttribute{
+				Description: schemaDowntimeServiceScopesDesc,
 				ElementType: types.StringType,
 				Computed:    true,
 			},
 			"service_exclude_scopes": schema.SetAttribute{
+				Description: schemaDowntimeServiceExcludeScopesDesc,
 				ElementType: types.StringType,
 				Computed:    true,
 			},
 			"role_scopes": schema.SetAttribute{
+				Description: schemaDowntimeRoleScopesDesc,
 				ElementType: types.StringType,
 				Computed:    true,
 			},
 			"role_exclude_scopes": schema.SetAttribute{
+				Description: schemaDowntimeRoleExcludeScopesDesc,
 				ElementType: types.StringType,
 				Computed:    true,
 			},
 			"monitor_scopes": schema.SetAttribute{
+				Description: schemaDowntimeMonitorScopesDesc,
 				ElementType: types.StringType,
 				Computed:    true,
 			},
 			"monitor_exclude_scopes": schema.SetAttribute{
+				Description: schemaDowntimeMonitorExcludeScopesDesc,
 				ElementType: types.StringType,
 				Computed:    true,
 			},

--- a/internal/provider/data_source_mackerel_downtime_test.go
+++ b/internal/provider/data_source_mackerel_downtime_test.go
@@ -1,0 +1,25 @@
+package provider_test
+
+import (
+	"context"
+	"testing"
+
+	fwdatasource "github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider"
+)
+
+func Test_MackerelDowntimeDataSource_schema(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	req := fwdatasource.SchemaRequest{}
+	resp := fwdatasource.SchemaResponse{}
+	provider.NewMackerelDowntimeDataSource().Schema(ctx, req, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %+v", resp.Diagnostics)
+	}
+
+	if diags := resp.Schema.ValidateImplementation(ctx); diags.HasError() {
+		t.Fatalf("schema validation diagnostics: %+v", diags)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -86,6 +86,7 @@ func (m *mackerelProvider) Resources(context.Context) []func() resource.Resource
 		NewMackerelAlertGroupSettingResource,
 		NewMackerelChannelResource,
 		NewMackerelDashboardResource,
+		NewMackerelDowntimeResource,
 		NewMackerelMonitorResource,
 		NewMackerelNotificationGroupResource,
 		NewMackerelRoleResource,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -100,6 +100,7 @@ func (m *mackerelProvider) DataSources(context.Context) []func() datasource.Data
 		NewMackerelAlertGroupSettingDataSource,
 		NewMackerelChannelDataSource,
 		NewMackerelDashboardDataSource,
+		NewMackerelDowntimeDataSource,
 		NewMackerelMonitorDataSource,
 		NewMackerelNotificationGroupDataSource,
 		NewMackerelRoleDataSource,

--- a/internal/provider/resource_mackerel_downtime.go
+++ b/internal/provider/resource_mackerel_downtime.go
@@ -129,7 +129,7 @@ const (
 	schemaDowntimeMemoDesc            = "The notes for the downtime."
 	schemaDowntimeStartDesc           = "The starting time (in epoch seconds) of the downtime."
 	schemaDowntimeDurationDesc        = "The duration (in minutes) of the downtime."
-	schemaDowntimeRecurrenceDesc      = "The configuration for repeating occurences."
+	schemaDowntimeRecurrenceDesc      = "The configuration for repeating occurrences."
 	schemaDowntimeRecurrence_typeDesc = "The recurrence options." +
 		"Valid options are `hourly`, `daily`, `weekly`, `monthly` or `yearly`."
 	schemaDowntimeRecurrence_intervalDesc = "The recurrence interval."

--- a/internal/provider/resource_mackerel_downtime.go
+++ b/internal/provider/resource_mackerel_downtime.go
@@ -123,30 +123,59 @@ func (r *mackerelDowntimeResource) ImportState(ctx context.Context, req resource
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
+const (
+	schemaDowntimeIDDesc              = "The id of the downtime."
+	schemaDowntimeNameDesc            = "The name of the downtime."
+	schemaDowntimeMemoDesc            = "The notes for the downtime."
+	schemaDowntimeStartDesc           = "The starting time (in epoch seconds) of the downtime."
+	schemaDowntimeDurationDesc        = "The duration (in minutes) of the downtime."
+	schemaDowntimeRecurrenceDesc      = "The configuration for repeating occurences."
+	schemaDowntimeRecurrence_typeDesc = "The recurrence options." +
+		"Valid options are `hourly`, `daily`, `weekly`, `monthly` or `yearly`."
+	schemaDowntimeRecurrence_intervalDesc = "The recurrence interval."
+	schemaDowntimeRecurrence_weekdaysDesc = "The set of the day of the week." +
+		"Valid values are `Sunday`, `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday` or `Saturday`." +
+		"Only available when the `type` is set to `weekly`."
+	schemaDowntimeRecurrence_untilDesc     = "The time at which recurrence ends (in epoch seconds)."
+	schemaDowntimeServiceScopesDesc        = "The set of target service names."
+	schemaDowntimeServiceExcludeScopesDesc = "The set of excluded service names."
+	schemaDowntimeRoleScopesDesc           = "The set of target role IDs."
+	schemaDowntimeRoleExcludeScopesDesc    = "The set of excluded role IDs."
+	schemaDowntimeMonitorScopesDesc        = "The set of target monitor IDs."
+	schemaDowntimeMonitorExcludeScopesDesc = "The set of excluded monitor IDs."
+)
+
 func schemaDowntimeResource() schema.Schema {
 	s := schema.Schema{
+		Description: "This resource allows creating and management of downtimes.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Computed: true,
+				Description: schemaDowntimeIDDesc,
+				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(), // immutable
 				},
 			},
 			"name": schema.StringAttribute{
-				Required: true,
+				Description: schemaDowntimeNameDesc,
+				Required:    true,
 			},
 			"memo": schema.StringAttribute{
-				Optional: true,
-				Computed: true,
-				Default:  stringdefault.StaticString(""),
+				Description: schemaDowntimeMemoDesc,
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 			},
 			"start": schema.Int64Attribute{
-				Required: true,
+				Description: schemaDowntimeStartDesc,
+				Required:    true,
 			},
 			"duration": schema.Int64Attribute{
-				Required: true,
+				Description: schemaDowntimeDurationDesc,
+				Required:    true,
 			},
 			"service_scopes": schema.SetAttribute{
+				Description: schemaDowntimeServiceScopesDesc,
 				ElementType: types.StringType,
 				Optional:    true,
 				Validators: []validator.Set{
@@ -154,6 +183,7 @@ func schemaDowntimeResource() schema.Schema {
 				},
 			},
 			"service_exclude_scopes": schema.SetAttribute{
+				Description: schemaDowntimeServiceExcludeScopesDesc,
 				ElementType: types.StringType,
 				Optional:    true,
 				Validators: []validator.Set{
@@ -161,41 +191,50 @@ func schemaDowntimeResource() schema.Schema {
 				},
 			},
 			"role_scopes": schema.SetAttribute{
+				Description: schemaDowntimeRoleScopesDesc,
 				ElementType: types.StringType,
 				Optional:    true,
 			},
 			"role_exclude_scopes": schema.SetAttribute{
+				Description: schemaDowntimeRoleExcludeScopesDesc,
 				ElementType: types.StringType,
 				Optional:    true,
 			},
 			"monitor_scopes": schema.SetAttribute{
+				Description: schemaDowntimeMonitorScopesDesc,
 				ElementType: types.StringType,
 				Optional:    true,
 			},
 			"monitor_exclude_scopes": schema.SetAttribute{
+				Description: schemaDowntimeMonitorExcludeScopesDesc,
 				ElementType: types.StringType,
 				Optional:    true,
 			},
 		},
 		Blocks: map[string]schema.Block{
 			"recurrence": schema.ListNestedBlock{
+				Description: schemaDowntimeRecurrenceDesc,
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"type": schema.StringAttribute{
-							Required: true,
+							Description: schemaDowntimeRecurrence_typeDesc,
+							Required:    true,
 							Validators: []validator.String{
 								stringvalidator.OneOf("hourly", "daily", "weekly", "monthly", "yearly"),
 							},
 						},
 						"interval": schema.Int64Attribute{
-							Required: true,
+							Description: schemaDowntimeRecurrence_intervalDesc,
+							Required:    true,
 						},
 						"weekdays": schema.SetAttribute{
-							ElementType: types.StringType,
-							Optional:    true,
+							Description:         schemaDowntimeRecurrence_weekdaysDesc,
+							MarkdownDescription: schemaDowntimeRecurrence_weekdaysDesc,
+							ElementType:         types.StringType,
+							Optional:            true,
 							Validators: []validator.Set{
 								setvalidator.ValueStringsAre(
 									stringvalidator.OneOf(
@@ -206,9 +245,10 @@ func schemaDowntimeResource() schema.Schema {
 							},
 						},
 						"until": schema.Int64Attribute{
-							Optional: true,
-							Computed: true,
-							Default:  int64default.StaticInt64(0),
+							Description: schemaDowntimeRecurrence_untilDesc,
+							Optional:    true,
+							Computed:    true,
+							Default:     int64default.StaticInt64(0),
 						},
 					},
 				},

--- a/internal/provider/resource_mackerel_downtime.go
+++ b/internal/provider/resource_mackerel_downtime.go
@@ -1,0 +1,219 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel"
+)
+
+var (
+	_ resource.Resource                = (*mackerelDowntimeResource)(nil)
+	_ resource.ResourceWithConfigure   = (*mackerelDowntimeResource)(nil)
+	_ resource.ResourceWithImportState = (*mackerelDowntimeResource)(nil)
+)
+
+func NewMackerelDowntimeResource() resource.Resource {
+	return &mackerelDowntimeResource{}
+}
+
+type mackerelDowntimeResource struct {
+	Client *mackerel.Client
+}
+
+func (r *mackerelDowntimeResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_downtime"
+}
+
+func (r *mackerelDowntimeResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schemaDowntimeResource()
+}
+
+func (r *mackerelDowntimeResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	client, diags := retrieveClient(ctx, req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+	r.Client = client
+}
+
+func (r *mackerelDowntimeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data mackerel.DowntimeModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Create(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to create a downtime",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *mackerelDowntimeResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data mackerel.DowntimeModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Read(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to read a downtime",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *mackerelDowntimeResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data mackerel.DowntimeModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Update(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to update a downtime",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *mackerelDowntimeResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data mackerel.DowntimeModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Delete(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to delete a downtime",
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *mackerelDowntimeResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func schemaDowntimeResource() schema.Schema {
+	s := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(), // immutable
+				},
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"memo": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(""),
+			},
+			"start": schema.Int64Attribute{
+				Required: true,
+			},
+			"duration": schema.Int64Attribute{
+				Required: true,
+			},
+			"service_scopes": schema.SetAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+				Validators: []validator.Set{
+					setvalidator.ValueStringsAre(mackerel.ServiceNameValidator()),
+				},
+			},
+			"service_exclude_scopes": schema.SetAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+				Validators: []validator.Set{
+					setvalidator.ValueStringsAre(mackerel.ServiceNameValidator()),
+				},
+			},
+			"role_scopes": schema.SetAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			"role_exclude_scopes": schema.SetAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			"monitor_scopes": schema.SetAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			"monitor_exclude_scopes": schema.SetAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"recurrence": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"type": schema.StringAttribute{
+							Required: true,
+							Validators: []validator.String{
+								stringvalidator.OneOf("hourly", "daily", "weekly", "monthly", "yearly"),
+							},
+						},
+						"interval": schema.Int64Attribute{
+							Required: true,
+						},
+						"weekdays": schema.SetAttribute{
+							ElementType: types.StringType,
+							Optional:    true,
+							Validators: []validator.Set{
+								setvalidator.ValueStringsAre(
+									stringvalidator.OneOf(
+										"Sunday", "Monday", "Tuesday", "Wednesday",
+										"Thursday", "Friday", "Saturday",
+									),
+								),
+							},
+						},
+						"until": schema.Int64Attribute{
+							Optional: true,
+							Computed: true,
+							Default:  int64default.StaticInt64(0),
+						},
+					},
+				},
+			},
+		},
+	}
+	return s
+}

--- a/internal/provider/resource_mackerel_downtime_test.go
+++ b/internal/provider/resource_mackerel_downtime_test.go
@@ -1,0 +1,26 @@
+package provider_test
+
+import (
+	"context"
+	"testing"
+
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider"
+)
+
+func Test_MackerelDowntimeResource_schema(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	req := fwresource.SchemaRequest{}
+	resp := fwresource.SchemaResponse{}
+	provider.NewMackerelDowntimeResource().Schema(ctx, req, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %+v", resp.Diagnostics)
+	}
+
+	if diags := resp.Schema.ValidateImplementation(ctx); diags.HasError() {
+		t.Fatalf("schema validation diagnostics: %+v", diags)
+	}
+}

--- a/mackerel/provider.go
+++ b/mackerel/provider.go
@@ -96,6 +96,7 @@ func protoV5ProviderServer(provider *schema.Provider) tfprotov5.ProviderServer {
 		delete(provider.DataSourcesMap, "mackerel_alert_group_setting")
 		delete(provider.DataSourcesMap, "mackerel_channel")
 		delete(provider.DataSourcesMap, "mackerel_dashboard")
+		delete(provider.DataSourcesMap, "mackerel_downtime")
 		delete(provider.DataSourcesMap, "mackerel_monitor")
 		delete(provider.DataSourcesMap, "mackerel_notification_group")
 		delete(provider.DataSourcesMap, "mackerel_role")

--- a/mackerel/provider.go
+++ b/mackerel/provider.go
@@ -85,6 +85,7 @@ func protoV5ProviderServer(provider *schema.Provider) tfprotov5.ProviderServer {
 		delete(provider.ResourcesMap, "mackerel_alert_group_setting")
 		delete(provider.ResourcesMap, "mackerel_channel")
 		delete(provider.ResourcesMap, "mackerel_dashboard")
+		delete(provider.ResourcesMap, "mackerel_downtime")
 		delete(provider.ResourcesMap, "mackerel_monitor")
 		delete(provider.ResourcesMap, "mackerel_notification_group")
 		delete(provider.ResourcesMap, "mackerel_role")


### PR DESCRIPTION
Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ TF_ACC=1 go test -v ./mackerel/... -run "Acc(DataSource)?MackerelDowntime" -timeout 120m
2024/09/19 20:58:37 [INFO] mackerel: use terraform-plugin-framework based implementation
=== RUN   TestAccDataSourceMackerelDowntime
=== PAUSE TestAccDataSourceMackerelDowntime
=== RUN   TestAccDataSourceMackerelDowntimeNotMatchAnyDowntime
=== PAUSE TestAccDataSourceMackerelDowntimeNotMatchAnyDowntime
=== RUN   TestAccMackerelDowntime
=== PAUSE TestAccMackerelDowntime
=== CONT  TestAccDataSourceMackerelDowntime
=== CONT  TestAccMackerelDowntime
=== CONT  TestAccDataSourceMackerelDowntimeNotMatchAnyDowntime
--- PASS: TestAccDataSourceMackerelDowntimeNotMatchAnyDowntime (5.06s)
--- PASS: TestAccDataSourceMackerelDowntime (8.78s)
--- PASS: TestAccMackerelDowntime (12.77s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel 15.974s
```
