### PR TITLE
Reimplement `mackerel_aws_integration` resource with terraform-plugin-framework

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -84,6 +84,7 @@ func (m *mackerelProvider) Configure(ctx context.Context, req provider.Configure
 func (m *mackerelProvider) Resources(context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewMackerelAlertGroupSettingResource,
+		NewMackerelAWSIntegrationResource,
 		NewMackerelChannelResource,
 		NewMackerelDashboardResource,
 		NewMackerelDowntimeResource,

--- a/internal/provider/resource_mackerel_aws_integration.go
+++ b/internal/provider/resource_mackerel_aws_integration.go
@@ -122,22 +122,45 @@ func (_ *mackerelAWSIntegrationResource) ImportState(ctx context.Context, req re
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
+const (
+	schemaAWSIntegrationIDDesc           = "The ID of the AWS integration."
+	schemaAWSIntegrationNameDesc         = "The name of the AWS integration."
+	schemaAWSIntegrationMemoDesc         = "The notes related to the AWS integration."
+	schemaAWSIntegrationKeyDesc          = "The AWS access key ID for the integration."
+	schemaAWSIntegrationSecretKeyDesc    = "The AWS secret access key for the integration."
+	schemaAWSIntegrationRoleARNDesc      = "The AWS IAM role resource name (ARN) for the integration."
+	schemaAWSIntegrationExternalIDDesc   = "The AWS IAM role external ID used during integration."
+	schemaAWSIntegrationRegionDesc       = "The AWS region in which the integration will be enabled."
+	schemaAWSIntegrationIncludedTagsDesc = "The comma separated list of tags to be included in the integration."
+	schemaAWSIntegrationExcludedTagsDesc = "The comma separated list of tags to be excluded in the integration."
+
+	schemaAWSIntegrationServiceDesc                    = "The settings of each AWS service."
+	schemaAWSIntegrationServiceEnableDesc              = "Whether integration settings are enabled. Default is `true`."
+	schemaAWSIntegrationServiceRoleDesc                = "The ID of the role to be assigned to the service."
+	schemaAWSIntegrationServiceExcludedMetricsDesc     = "The list of the metrics to be excluded."
+	schemaAWSIntegrationServiceRetireAutomaticallyDesc = "Whether automatic retirement is enabled."
+)
+
 func schemaAWSIntegrationResource() schema.Schema {
 	serviceSchema := schema.SetNestedBlock{
+		Description: schemaAWSIntegrationServiceDesc,
 		Validators: []validator.Set{
 			setvalidator.SizeAtMost(1),
 		},
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				"enable": schema.BoolAttribute{
-					Optional: true,
-					Computed: true,
-					Default:  booldefault.StaticBool(true),
+					Description: schemaAWSIntegrationServiceEnableDesc,
+					Optional:    true,
+					Computed:    true,
+					Default:     booldefault.StaticBool(true),
 				},
 				"role": schema.StringAttribute{
-					Optional: true,
+					Description: schemaAWSIntegrationServiceRoleDesc,
+					Optional:    true,
 				},
 				"excluded_metrics": schema.ListAttribute{
+					Description: schemaAWSIntegrationServiceExcludedMetricsDesc,
 					ElementType: types.StringType,
 					Optional:    true,
 				},
@@ -145,27 +168,32 @@ func schemaAWSIntegrationResource() schema.Schema {
 		},
 	}
 	serviceSchemaWithRetireAutomatically := schema.SetNestedBlock{
+		Description: schemaAWSIntegrationServiceDesc,
 		Validators: []validator.Set{
 			setvalidator.SizeAtMost(1),
 		},
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				"enable": schema.BoolAttribute{
-					Optional: true,
-					Computed: true,
-					Default:  booldefault.StaticBool(true),
+					Description: schemaAWSIntegrationServiceEnableDesc,
+					Optional:    true,
+					Computed:    true,
+					Default:     booldefault.StaticBool(true),
 				},
 				"role": schema.StringAttribute{
-					Optional: true,
+					Description: schemaAWSIntegrationServiceRoleDesc,
+					Optional:    true,
 				},
 				"excluded_metrics": schema.ListAttribute{
+					Description: schemaAWSIntegrationServiceExcludedMetricsDesc,
 					ElementType: types.StringType,
 					Optional:    true,
 				},
 				"retire_automatically": schema.BoolAttribute{
-					Optional: true,
-					Computed: true,
-					Default:  booldefault.StaticBool(false),
+					Description: schemaAWSIntegrationServiceRetireAutomaticallyDesc,
+					Optional:    true,
+					Computed:    true,
+					Default:     booldefault.StaticBool(false),
 				},
 			},
 		},
@@ -202,69 +230,80 @@ func schemaAWSIntegrationResource() schema.Schema {
 	}
 
 	schema := schema.Schema{
+		Description: "This resource allows creating and management of the AWS integration.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Computed: true,
+				Description: schemaAWSIntegrationIDDesc,
+				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(), // immutable
 				},
 			},
 			"name": schema.StringAttribute{
-				Required: true,
+				Description: schemaAWSIntegrationNameDesc,
+				Required:    true,
 			},
 			"memo": schema.StringAttribute{
-				Optional: true,
-				Computed: true,
-				Default:  stringdefault.StaticString(""),
+				Description: schemaAWSIntegrationMemoDesc,
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 			},
 			"key": schema.StringAttribute{
-				Optional:  true,
-				Sensitive: true,
-				Computed:  true,
-				Default:   stringdefault.StaticString(""),
+				Description: schemaAWSIntegrationKeyDesc,
+				Optional:    true,
+				Sensitive:   true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 				Validators: []validator.String{
 					// With Access Key, secret access key is need too.
 					stringvalidator.AlsoRequires(path.MatchRoot("secret_key")),
 				},
 			},
 			"secret_key": schema.StringAttribute{
-				Optional:  true,
-				Sensitive: true,
-				Computed:  true,
-				Default:   stringdefault.StaticString(""),
+				Description: schemaAWSIntegrationSecretKeyDesc,
+				Optional:    true,
+				Sensitive:   true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 				Validators: []validator.String{
 					// Secret access key cannot be set alone
 					stringvalidator.AlsoRequires(path.MatchRoot("key")),
 				},
 			},
 			"role_arn": schema.StringAttribute{
-				Optional: true,
-				Computed: true,
-				Default:  stringdefault.StaticString(""),
+				Description: schemaAWSIntegrationRoleARNDesc,
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 			},
 			"external_id": schema.StringAttribute{
-				Optional: true,
-				Computed: true,
-				Default:  stringdefault.StaticString(""),
+				Description: schemaAWSIntegrationExternalIDDesc,
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 				Validators: []validator.String{
 					// External ID cannot be set alone
 					stringvalidator.AlsoRequires(path.MatchRoot("role_arn")),
 				},
 			},
 			"region": schema.StringAttribute{
-				Optional: true,
-				Computed: true,
-				Default:  stringdefault.StaticString(""),
+				Description: schemaAWSIntegrationRegionDesc,
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 			},
 			"included_tags": schema.StringAttribute{
-				Optional: true,
-				Computed: true,
-				Default:  stringdefault.StaticString(""),
+				Description: schemaAWSIntegrationIncludedTagsDesc,
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 			},
 			"excluded_tags": schema.StringAttribute{
-				Optional: true,
-				Computed: true,
-				Default:  stringdefault.StaticString(""),
+				Description: schemaAWSIntegrationExcludedTagsDesc,
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 			},
 		},
 		Blocks: services,

--- a/internal/provider/resource_mackerel_aws_integration.go
+++ b/internal/provider/resource_mackerel_aws_integration.go
@@ -1,0 +1,273 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel"
+)
+
+var (
+	_ resource.Resource                = (*mackerelAWSIntegrationResource)(nil)
+	_ resource.ResourceWithConfigure   = (*mackerelAWSIntegrationResource)(nil)
+	_ resource.ResourceWithImportState = (*mackerelAWSIntegrationResource)(nil)
+)
+
+func NewMackerelAWSIntegrationResource() resource.Resource {
+	return &mackerelAWSIntegrationResource{}
+}
+
+type mackerelAWSIntegrationResource struct {
+	Client *mackerel.Client
+}
+
+func (_ *mackerelAWSIntegrationResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_aws_integration"
+}
+
+func (_ *mackerelAWSIntegrationResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schemaAWSIntegrationResource()
+}
+
+func (r *mackerelAWSIntegrationResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	client, diags := retrieveClient(ctx, req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+	r.Client = client
+}
+
+func (r *mackerelAWSIntegrationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data mackerel.AWSIntegrationModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Create(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to create aws integration settings",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *mackerelAWSIntegrationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data mackerel.AWSIntegrationModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Read(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to read aws integration settings",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *mackerelAWSIntegrationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data mackerel.AWSIntegrationModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Update(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to update aws integration settings",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *mackerelAWSIntegrationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data mackerel.AWSIntegrationModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := data.Delete(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to delete aws integration settings",
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (_ *mackerelAWSIntegrationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func schemaAWSIntegrationResource() schema.Schema {
+	serviceSchema := schema.SetNestedBlock{
+		Validators: []validator.Set{
+			setvalidator.SizeAtMost(1),
+		},
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"enable": schema.BoolAttribute{
+					Optional: true,
+					Computed: true,
+					Default:  booldefault.StaticBool(true),
+				},
+				"role": schema.StringAttribute{
+					Optional: true,
+				},
+				"excluded_metrics": schema.ListAttribute{
+					ElementType: types.StringType,
+					Optional:    true,
+				},
+			},
+		},
+	}
+	serviceSchemaWithRetireAutomatically := schema.SetNestedBlock{
+		Validators: []validator.Set{
+			setvalidator.SizeAtMost(1),
+		},
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"enable": schema.BoolAttribute{
+					Optional: true,
+					Computed: true,
+					Default:  booldefault.StaticBool(true),
+				},
+				"role": schema.StringAttribute{
+					Optional: true,
+				},
+				"excluded_metrics": schema.ListAttribute{
+					ElementType: types.StringType,
+					Optional:    true,
+				},
+				"retire_automatically": schema.BoolAttribute{
+					Optional: true,
+					Computed: true,
+					Default:  booldefault.StaticBool(false),
+				},
+			},
+		},
+	}
+
+	services := map[string]schema.Block{
+		"ec2":         serviceSchemaWithRetireAutomatically,
+		"elb":         serviceSchema,
+		"alb":         serviceSchema,
+		"nlb":         serviceSchema,
+		"rds":         serviceSchemaWithRetireAutomatically,
+		"redshift":    serviceSchema,
+		"elasticache": serviceSchemaWithRetireAutomatically,
+		"sqs":         serviceSchema,
+		"lambda":      serviceSchema,
+		"dynamodb":    serviceSchema,
+		"cloudfront":  serviceSchema,
+		"api_gateway": serviceSchema,
+		"kinesis":     serviceSchema,
+		"s3":          serviceSchema,
+		"es":          serviceSchema,
+		"ecs_cluster": serviceSchema,
+		"ses":         serviceSchema,
+		"states":      serviceSchema,
+		"efs":         serviceSchema,
+		"firehose":    serviceSchema,
+		"batch":       serviceSchema,
+		"waf":         serviceSchema,
+		"billing":     serviceSchema,
+		"route53":     serviceSchema,
+		"connect":     serviceSchema,
+		"docdb":       serviceSchema,
+		"codebuild":   serviceSchema,
+	}
+
+	schema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(), // immutable
+				},
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"memo": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(""),
+			},
+			"key": schema.StringAttribute{
+				Optional:  true,
+				Sensitive: true,
+				Computed:  true,
+				Default:   stringdefault.StaticString(""),
+				Validators: []validator.String{
+					// With Access Key, secret access key is need too.
+					stringvalidator.AlsoRequires(path.MatchRoot("secret_key")),
+				},
+			},
+			"secret_key": schema.StringAttribute{
+				Optional:  true,
+				Sensitive: true,
+				Computed:  true,
+				Default:   stringdefault.StaticString(""),
+				Validators: []validator.String{
+					// Secret access key cannot be set alone
+					stringvalidator.AlsoRequires(path.MatchRoot("key")),
+				},
+			},
+			"role_arn": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(""),
+			},
+			"external_id": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(""),
+				Validators: []validator.String{
+					// External ID cannot be set alone
+					stringvalidator.AlsoRequires(path.MatchRoot("role_arn")),
+				},
+			},
+			"region": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(""),
+			},
+			"included_tags": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(""),
+			},
+			"excluded_tags": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(""),
+			},
+		},
+		Blocks: services,
+	}
+	return schema
+}

--- a/internal/provider/resource_mackerel_aws_integration.go
+++ b/internal/provider/resource_mackerel_aws_integration.go
@@ -141,6 +141,38 @@ const (
 	schemaAWSIntegrationServiceRetireAutomaticallyDesc = "Whether automatic retirement is enabled."
 )
 
+var awsIntegrationServices = map[string]struct {
+	supportsAutoRetire bool
+}{
+	"ec2":         {supportsAutoRetire: true},
+	"elb":         {},
+	"alb":         {},
+	"nlb":         {},
+	"rds":         {supportsAutoRetire: true},
+	"redshift":    {},
+	"elasticache": {supportsAutoRetire: true},
+	"sqs":         {},
+	"lambda":      {},
+	"dynamodb":    {},
+	"cloudfront":  {},
+	"api_gateway": {},
+	"kinesis":     {},
+	"s3":          {},
+	"es":          {},
+	"ecs_cluster": {},
+	"ses":         {},
+	"states":      {},
+	"efs":         {},
+	"firehose":    {},
+	"batch":       {},
+	"waf":         {},
+	"billing":     {},
+	"route53":     {},
+	"connect":     {},
+	"docdb":       {},
+	"codebuild":   {},
+}
+
 func schemaAWSIntegrationResource() schema.Schema {
 	serviceSchema := schema.SetNestedBlock{
 		Description: schemaAWSIntegrationServiceDesc,
@@ -199,34 +231,15 @@ func schemaAWSIntegrationResource() schema.Schema {
 		},
 	}
 
-	services := map[string]schema.Block{
-		"ec2":         serviceSchemaWithRetireAutomatically,
-		"elb":         serviceSchema,
-		"alb":         serviceSchema,
-		"nlb":         serviceSchema,
-		"rds":         serviceSchemaWithRetireAutomatically,
-		"redshift":    serviceSchema,
-		"elasticache": serviceSchemaWithRetireAutomatically,
-		"sqs":         serviceSchema,
-		"lambda":      serviceSchema,
-		"dynamodb":    serviceSchema,
-		"cloudfront":  serviceSchema,
-		"api_gateway": serviceSchema,
-		"kinesis":     serviceSchema,
-		"s3":          serviceSchema,
-		"es":          serviceSchema,
-		"ecs_cluster": serviceSchema,
-		"ses":         serviceSchema,
-		"states":      serviceSchema,
-		"efs":         serviceSchema,
-		"firehose":    serviceSchema,
-		"batch":       serviceSchema,
-		"waf":         serviceSchema,
-		"billing":     serviceSchema,
-		"route53":     serviceSchema,
-		"connect":     serviceSchema,
-		"docdb":       serviceSchema,
-		"codebuild":   serviceSchema,
+	services := make(map[string]schema.Block, len(awsIntegrationServices))
+	for name, spec := range awsIntegrationServices {
+		var block schema.Block
+		if spec.supportsAutoRetire {
+			block = serviceSchemaWithRetireAutomatically
+		} else {
+			block = serviceSchema
+		}
+		services[name] = block
 	}
 
 	schema := schema.Schema{

--- a/internal/provider/resource_mackerel_aws_integration_test.go
+++ b/internal/provider/resource_mackerel_aws_integration_test.go
@@ -1,0 +1,25 @@
+package provider_test
+
+import (
+	"context"
+	"testing"
+
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider"
+)
+
+func Test_MackerelAWSIntegrationResource_schema(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	req := fwresource.SchemaRequest{}
+	resp := fwresource.SchemaResponse{}
+	if provider.NewMackerelAWSIntegrationResource().Schema(ctx, req, &resp); resp.Diagnostics.HasError() {
+		t.Fatalf("schema method diagnostics: %+v", resp.Diagnostics)
+	}
+
+	if diags := resp.Schema.ValidateImplementation(ctx); diags.HasError() {
+		t.Fatalf("schema validation diagnostics: %+v", diags)
+	}
+}

--- a/mackerel/provider.go
+++ b/mackerel/provider.go
@@ -83,6 +83,7 @@ func protoV5ProviderServer(provider *schema.Provider) tfprotov5.ProviderServer {
 
 		// Resources
 		delete(provider.ResourcesMap, "mackerel_alert_group_setting")
+		delete(provider.ResourcesMap, "mackerel_aws_integration")
 		delete(provider.ResourcesMap, "mackerel_channel")
 		delete(provider.ResourcesMap, "mackerel_dashboard")
 		delete(provider.ResourcesMap, "mackerel_downtime")

--- a/mackerel/resource_mackerel_aws_integration_test.go
+++ b/mackerel/resource_mackerel_aws_integration_test.go
@@ -303,7 +303,6 @@ resource "mackerel_aws_integration" "foo" {
 
   ec2 {
     enable               = true
-    role                 = ""
     excluded_metrics     = []
     retire_automatically = true
   }
@@ -357,7 +356,6 @@ resource "mackerel_aws_integration" "foo" {
 
   ec2 {
     enable               = true
-    role                 = ""
     excluded_metrics     = []
     retire_automatically = true
   }


### PR DESCRIPTION
Part of #243 

Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ MACKEREL_EXPERIMENTAL_TFFRAMEWORK=1 make testacc TESTS='"AccMackerelAWSIntegration"'
TF_ACC=1 go test -v ./mackerel/... -run "AccMackerelAWSIntegration" -timeout 120m
2024/10/29 16:17:00 [INFO] mackerel: use terraform-plugin-framework based implementation
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== RUN   TestAccMackerelAWSIntegrationCredentials
=== PAUSE TestAccMackerelAWSIntegrationCredentials
=== CONT  TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationCredentials
--- PASS: TestAccMackerelAWSIntegrationCredentials (6.27s)
--- PASS: TestAccMackerelAWSIntegrationIAMRole (6.62s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel 7.743s
```
