### PR TITLE
fix: downtime test

### DIFF
--- a/mackerel/resource_mackerel_downtime_test.go
+++ b/mackerel/resource_mackerel_downtime_test.go
@@ -28,7 +28,7 @@ func TestAccMackerelDowntime(t *testing.T) {
 					testAccCheckMackerelDowntimeExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "memo", ""),
-					resource.TestCheckResourceAttr(resourceName, "start", "1735707600"),
+					resource.TestCheckResourceAttr(resourceName, "start", "2051254800"),
 					resource.TestCheckResourceAttr(resourceName, "duration", "3600"),
 					resource.TestCheckResourceAttr(resourceName, "recurrence.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "service_scopes.#", "0"),
@@ -46,13 +46,13 @@ func TestAccMackerelDowntime(t *testing.T) {
 					testAccCheckMackerelDowntimeExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", nameUpdated),
 					resource.TestCheckResourceAttr(resourceName, "memo", "This downtime is managed by Terraform."),
-					resource.TestCheckResourceAttr(resourceName, "start", "1735707600"),
+					resource.TestCheckResourceAttr(resourceName, "start", "2051254800"),
 					resource.TestCheckResourceAttr(resourceName, "duration", "3600"),
 					resource.TestCheckResourceAttr(resourceName, "recurrence.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "recurrence.0.type", "weekly"),
 					resource.TestCheckResourceAttr(resourceName, "recurrence.0.interval", "2"),
 					resource.TestCheckResourceAttr(resourceName, "recurrence.0.weekdays.#", "5"),
-					resource.TestCheckResourceAttr(resourceName, "recurrence.0.until", "1767193199"),
+					resource.TestCheckResourceAttr(resourceName, "recurrence.0.until", "2082725999"),
 					resource.TestCheckResourceAttr(resourceName, "service_scopes.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "service_exclude_scopes.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "role_scopes.#", "1"),
@@ -120,7 +120,7 @@ func testAccMackerelDowntimeConfig(name string) string {
 	return fmt.Sprintf(`
 resource "mackerel_downtime" "foo" {
   name = "%s"
-  start = 1735707600
+  start = 2051254800
   duration = 3600
 }
 `, name)
@@ -149,7 +149,7 @@ resource "mackerel_role" "include" {
 resource "mackerel_downtime" "foo" {
   name = "%s"
   memo = "This downtime is managed by Terraform."
-  start = 1735707600
+  start = 2051254800
   duration = 3600
 
   recurrence {
@@ -161,7 +161,7 @@ resource "mackerel_downtime" "foo" {
       "Wednesday",
       "Thursday",
       "Friday"]
-    until = 1767193199
+    until = 2082725999
   }
 
   service_scopes = [


### PR DESCRIPTION
Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS='AccMackerelDowntime'
TF_ACC=1 go test -v ./mackerel/... -run AccMackerelDowntime -timeout 120m
2025/01/14 18:42:14 [INFO] mackerel: use terraform-plugin-framework based implementation
=== RUN   TestAccMackerelDowntime
=== PAUSE TestAccMackerelDowntime
=== CONT  TestAccMackerelDowntime
--- PASS: TestAccMackerelDowntime (5.87s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel (cached)
```
