### PR TITLE
range needs one of relative or absolute

### DIFF
--- a/mackerel/resource_mackerel_dashboard.go
+++ b/mackerel/resource_mackerel_dashboard.go
@@ -249,10 +249,11 @@ func resourceMackerelDashboard() *schema.Resource {
 							},
 						},
 						"range": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem:     dashboardRangeResource,
+							Type:         schema.TypeList,
+							Optional:     true,
+							MaxItems:     1,
+							ExactlyOneOf: []string{"relative", "absolute"},
+							Elem:         dashboardRangeResource,
 						},
 						"layout": {
 							Type:     schema.TypeList,

--- a/mackerel/resource_mackerel_dashboard.go
+++ b/mackerel/resource_mackerel_dashboard.go
@@ -204,6 +204,7 @@ func resourceMackerelDashboard() *schema.Resource {
 						"service": {
 							Type:     schema.TypeList,
 							Optional: true,
+							MinItems: 1,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -249,11 +250,11 @@ func resourceMackerelDashboard() *schema.Resource {
 							},
 						},
 						"range": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							MaxItems:     1,
-							ExactlyOneOf: []string{"relative", "absolute"},
-							Elem:         dashboardRangeResource,
+							Type:     schema.TypeList,
+							Optional: true,
+							MinItems: 1,
+							MaxItems: 1,
+							Elem:     dashboardRangeResource,
 						},
 						"layout": {
 							Type:     schema.TypeList,

--- a/mackerel/resource_mackerel_dashboard.go
+++ b/mackerel/resource_mackerel_dashboard.go
@@ -400,7 +400,7 @@ func expandDashboardWidgets(d *schema.ResourceData) []mackerel.Widget {
 		for _, graph := range graphs {
 			g := graph.(map[string]interface{})
 			var r mackerel.Range
-			if v, ok := g["range"].([]interface{}); ok && len(v) > 0 {
+			if v, ok := g["range"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 				r = expandDashboardRange(v)
 			}
 			title := g["title"].(string)

--- a/mackerel/resource_mackerel_dashboard_test.go
+++ b/mackerel/resource_mackerel_dashboard_test.go
@@ -276,10 +276,8 @@ func TestAccMackerelDashboardAlertStatus(t *testing.T) {
 }
 
 func TestAccMackerelDashboardEmptyInvalidRange(t *testing.T) {
-	//resourceName := "mackerel_dashboard.graph"
 	rand := acctest.RandString(5)
 	title := fmt.Sprintf("tf-dashboard graph %s", rand)
-	//titleUpdated := fmt.Sprintf("tf-dashboard graph %s updated", rand)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },


### PR DESCRIPTION
Refs: https://github.com/mackerelio-labs/terraform-provider-mackerel/issues/252

If you write `range {}` and empty range block in the graph block of mackerel_dashboard resource, it will cause on nil type cast and panic when you apply. The range block must contain either a relative block or an absolute block.

I change to followings : 

- Guard against type casts of nil.
- If an empty range block is specified, issue a warning.

Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS=TestAccMackerelDashboardEmptyInvalidRange
TF_ACC=1 go test -v ./... -run TestAccMackerelDashboardEmptyInvalidRange -timeout 120m
?   	github.com/mackerelio-labs/terraform-provider-mackerel	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/mackerelio-labs/terraform-provider-mackerel/internal/planmodifierutil	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/mackerelio-labs/terraform-provider-mackerel/internal/typeutil	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/mackerelio-labs/terraform-provider-mackerel/internal/validatorutil	(cached) [no tests to run]
=== RUN   TestAccMackerelDashboardEmptyInvalidRange
=== PAUSE TestAccMackerelDashboardEmptyInvalidRange
=== CONT  TestAccMackerelDashboardEmptyInvalidRange
--- PASS: TestAccMackerelDashboardEmptyInvalidRange (0.65s)
PASS
ok  	github.com/mackerelio-labs/terraform-provider-mackerel/mackerel	1.514s
...
```
