### PR TITLE
Fix monitor incompatibility between SDK and framework

### DIFF
--- a/internal/mackerel/monitor.go
+++ b/internal/mackerel/monitor.go
@@ -123,16 +123,6 @@ func (m *MonitorModel) Read(ctx context.Context, client *Client) error {
 		return err
 	}
 
-	if len(m.ExternalMonitor) > 0 && len(remote.ExternalMonitor) > 0 {
-		em := m.ExternalMonitor[0]
-		rem := &remote.ExternalMonitor[0]
-
-		// preserve null
-		if em.Headers == nil && len(rem.Headers) == 0 {
-			rem.Headers = nil
-		}
-	}
-
 	*m = remote
 
 	return nil
@@ -171,12 +161,8 @@ func newMonitor(mackerelMonitor mackerel.Monitor) (MonitorModel, error) {
 			Duration:         types.Int64Value(int64(m.Duration)),
 			MaxCheckAttempts: types.Int64Value(int64(m.MaxCheckAttempts)),
 		}
-		if len(m.Scopes) > 0 {
-			hm.Scopes = normalizeScopes(m.Scopes)
-		}
-		if len(m.ExcludeScopes) > 0 {
-			hm.ExcludeScopes = normalizeScopes(m.ExcludeScopes)
-		}
+		hm.Scopes = normalizeScopes(m.Scopes)
+		hm.ExcludeScopes = normalizeScopes(m.ExcludeScopes)
 
 		model.HostMetricMonitor = []MonitorHostMetric{hm}
 	case *mackerel.MonitorServiceMetric:
@@ -231,12 +217,8 @@ func newMonitor(mackerelMonitor mackerel.Monitor) (MonitorModel, error) {
 		cm := MonitorConnectivity{
 			AlertStatusOnGone: types.StringValue(m.AlertStatusOnGone),
 		}
-		if len(m.Scopes) > 0 {
-			cm.Scopes = normalizeScopes(m.Scopes)
-		}
-		if len(m.ExcludeScopes) > 0 {
-			cm.ExcludeScopes = normalizeScopes(m.ExcludeScopes)
-		}
+		cm.Scopes = normalizeScopes(m.Scopes)
+		cm.ExcludeScopes = normalizeScopes(m.ExcludeScopes)
 		model.ConnectivityMonitor = []MonitorConnectivity{cm}
 	case *mackerel.MonitorExternalHTTP:
 		model.Memo = types.StringValue(m.Memo)

--- a/internal/mackerel/monitor_test.go
+++ b/internal/mackerel/monitor_test.go
@@ -43,6 +43,8 @@ func Test_Monitor_toModel(t *testing.T) {
 					Critical:         typeutil.NewFloatStringValue(""),
 					Duration:         types.Int64Value(1),
 					MaxCheckAttempts: types.Int64Value(1),
+					Scopes:           []string{},
+					ExcludeScopes:    []string{},
 				}},
 			},
 		},
@@ -280,6 +282,8 @@ func Test_Monitor_toModel(t *testing.T) {
 
 				ConnectivityMonitor: []MonitorConnectivity{{
 					AlertStatusOnGone: types.StringValue("CRITICAL"),
+					Scopes:            []string{},
+					ExcludeScopes:     []string{},
 				}},
 			},
 		},

--- a/internal/provider/resource_mackerel_monitor.go
+++ b/internal/provider/resource_mackerel_monitor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel"
+	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/planmodifierutil"
 	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/typeutil"
 	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/validatorutil"
 )
@@ -275,17 +276,21 @@ func schemaMonitorMaxCheckAttemptsAttr(defaultAttempts uint) schema.Int64Attribu
 
 func schemaMonitorResourceScopesAttr() schema.SetAttribute {
 	return schema.SetAttribute{
-		ElementType: types.StringType,
-		Description: schemaMonitorScopesDesc,
-		Optional:    true,
+		ElementType:   types.StringType,
+		Description:   schemaMonitorScopesDesc,
+		Optional:      true,
+		Computed:      true,
+		PlanModifiers: []planmodifier.Set{planmodifierutil.NilRelaxedSet()},
 	}
 }
 
 func schemaMonitorResourceExcludeScopesAttr() schema.SetAttribute {
 	return schema.SetAttribute{
-		ElementType: types.StringType,
-		Description: schemaMonitorExcludeScopesDesc,
-		Optional:    true,
+		ElementType:   types.StringType,
+		Description:   schemaMonitorExcludeScopesDesc,
+		Optional:      true,
+		Computed:      true,
+		PlanModifiers: []planmodifier.Set{planmodifierutil.NilRelaxedSet()},
 	}
 }
 
@@ -519,10 +524,12 @@ func schemaMonitorResourceExternalBlock() schema.Block {
 					Default:     stringdefault.StaticString(""),
 				},
 				"headers": schema.MapAttribute{
-					ElementType: types.StringType,
-					Description: schemaMonitorExternal_HeadersDesc,
-					Sensitive:   true,
-					Optional:    true,
+					ElementType:   types.StringType,
+					Description:   schemaMonitorExternal_HeadersDesc,
+					Sensitive:     true,
+					Optional:      true,
+					Computed:      true,
+					PlanModifiers: []planmodifier.Map{planmodifierutil.NilRelaxedMap()},
 				},
 
 				"service": schema.StringAttribute{

--- a/internal/provider/resource_mackerel_monitor_test.go
+++ b/internal/provider/resource_mackerel_monitor_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider"
 )
 
@@ -22,5 +24,220 @@ func Test_MackerelMonitorResource_schema(t *testing.T) {
 
 	if diags := resp.Schema.ValidateImplementation(ctx); diags.HasError() {
 		t.Fatalf("schema validation diagnostics: %+v", diags)
+	}
+}
+
+func TestAccCompat_MackerelMonitorResource(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		config func(name string) string
+	}{
+		"host_metric/undefined": {
+			config: func(name string) string {
+				return `
+resource "mackerel_monitor" "host_metric" {
+  name = "` + name + `"
+  host_metric {
+    metric = "cpu.sys"
+    operator = ">"
+    warning = "80"
+    duration = 3
+  }
+}`
+			},
+		},
+		"host_metric/null": {
+			config: func(name string) string {
+				return `
+resource "mackerel_monitor" "host_metric" {
+  name = "` + name + `"
+  host_metric {
+    metric = "cpu.sys"
+    operator = ">"
+    warning = "80"
+    duration = 3
+    scopes = null
+    exclude_scopes = null
+  }
+}`
+			},
+		},
+		"host_metric/empty": {
+			config: func(name string) string {
+				return `
+resource "mackerel_monitor" "host_metric" {
+  name = "` + name + `"
+  host_metric {
+    metric = "cpu.sys"
+    operator = ">"
+    warning = "80"
+    duration = 3
+    scopes = []
+    exclude_scopes = []
+  }
+}`
+			},
+		},
+		"connectivity/undefined": {
+			config: func(name string) string {
+				return `
+resource "mackerel_monitor" "connectivity" {
+  name = "` + name + `"
+  connectivity {}
+}`
+			},
+		},
+		"connectivity/null": {
+			config: func(name string) string {
+				return `
+resource "mackerel_monitor" "connectivity" {
+  name = "` + name + `"
+  connectivity {
+    scopes = null
+    exclude_scopes = null
+  }
+}`
+			},
+		},
+		"connectivity/empty": {
+			config: func(name string) string {
+				return `
+resource "mackerel_monitor" "connectivity" {
+  name = "` + name + `"
+  connectivity {
+    scopes = []
+	exclude_scopes = []
+  }
+}`
+			},
+		},
+		"service_metric": {
+			config: func(name string) string {
+				return `
+resource "mackerel_service" "svc" {
+  name = "` + name + `-svc"
+}
+resource "mackerel_monitor" "service_metric" {
+  name = "` + name + `"
+  service_metric {
+    service = mackerel_service.svc.name
+    duration = 1	
+    metric = "custom.access.2xx_ratio"
+    operator = ">"
+    warning = "99.9"
+  }
+}`
+			},
+		},
+		"external": {
+			config: func(name string) string {
+				return `
+resource "mackerel_monitor" "external" {
+  name = "` + name + `"
+  external {
+    method = "GET"
+    url = "https://terraform-provider-mackerel.test/"
+  }
+}`
+			},
+		},
+		"external/null": {
+			config: func(name string) string {
+				return `
+resource "mackerel_monitor" "external" {
+  name = "` + name + `"
+  external {
+    method = "GET"
+    url = "https://terraform-provider-mackerel.test/"
+    headers = null
+  }
+}`
+			},
+		},
+		"external/empty": {
+			config: func(name string) string {
+				return `
+resource "mackerel_monitor" "external" {
+  name = "` + name + `"
+  external {
+    method = "GET"
+    url = "https://terraform-provider-mackerel.test/"
+    headers = {}
+  }
+}`
+			},
+		},
+		"expression": {
+			config: func(name string) string {
+				return `
+resource "mackerel_monitor" "expression" {
+  name = "` + name + `"
+  expression {
+    expression = "max(role(my-service:db, loadavg5))"
+    operator = ">"
+    warning = "0.7"
+  }
+}`
+			},
+		},
+		"anomaly_detection": {
+			config: func(name string) string {
+				return `
+resource "mackerel_service" "svc" {
+  name = "` + name + `-svc"
+}
+resource "mackerel_role" "role" {
+  service = mackerel_service.svc.name
+  name = "` + name + `-role"
+}
+resource "mackerel_monitor" "anomaly_detection" {
+  name = "` + name + `"
+  anomaly_detection {
+    warning_sensitivity = "insensitive"
+    scopes = [mackerel_role.role.id]
+  }
+}`
+			},
+		},
+		"query": {
+			config: func(name string) string {
+				return `
+resource "mackerel_monitor" "foo" {
+  name = "` + name + `"
+  query {
+    query = "container.cpu.utilization{k8s.deployment.name=\"httpbin\"}"
+    legend = "cpu.utilization {{k8s.node.name}}"
+    operator = ">"
+    warning = "70"
+  }
+}`
+			},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			name := acctest.RandomWithPrefix("tf-monitor-compat")
+			config := tt.config(name)
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() { preCheck(t) },
+				Steps: []resource.TestStep{
+					{
+						Config:                   config,
+						ProtoV5ProviderFactories: protoV5SDKProviderFactories,
+					},
+					stepNoPlanInFramework(config),
+					{
+						Config:                   config,
+						ProtoV5ProviderFactories: protoV5SDKProviderFactories,
+					},
+					stepNoPlanInFramework(config),
+				},
+			})
+		})
 	}
 }


### PR DESCRIPTION
This PR fixes inconsistency on `mackerel_monitor` resources between SDK and framework implementations.

Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS='Compat_MackerelMonitor'
TF_ACC=1 go test -v ./... -run Compat_MackerelMonitor -timeout 120m
?       github.com/mackerelio-labs/terraform-provider-mackerel  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel        0.600s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/planmodifierutil        (cached) [no tests to run]
=== RUN   TestAccCompat_MackerelMonitorResource
=== PAUSE TestAccCompat_MackerelMonitorResource
=== CONT  TestAccCompat_MackerelMonitorResource
=== RUN   TestAccCompat_MackerelMonitorResource/host_metric/undefined
=== PAUSE TestAccCompat_MackerelMonitorResource/host_metric/undefined
=== RUN   TestAccCompat_MackerelMonitorResource/host_metric/null
=== PAUSE TestAccCompat_MackerelMonitorResource/host_metric/null
=== RUN   TestAccCompat_MackerelMonitorResource/connectivity/null
=== PAUSE TestAccCompat_MackerelMonitorResource/connectivity/null
=== RUN   TestAccCompat_MackerelMonitorResource/connectivity/empty
=== PAUSE TestAccCompat_MackerelMonitorResource/connectivity/empty
=== RUN   TestAccCompat_MackerelMonitorResource/external
=== PAUSE TestAccCompat_MackerelMonitorResource/external
=== RUN   TestAccCompat_MackerelMonitorResource/external/null
=== PAUSE TestAccCompat_MackerelMonitorResource/external/null
=== RUN   TestAccCompat_MackerelMonitorResource/expression
=== PAUSE TestAccCompat_MackerelMonitorResource/expression
=== RUN   TestAccCompat_MackerelMonitorResource/query
=== PAUSE TestAccCompat_MackerelMonitorResource/query
=== RUN   TestAccCompat_MackerelMonitorResource/host_metric/empty
=== PAUSE TestAccCompat_MackerelMonitorResource/host_metric/empty
=== RUN   TestAccCompat_MackerelMonitorResource/connectivity/undefined
=== PAUSE TestAccCompat_MackerelMonitorResource/connectivity/undefined
=== RUN   TestAccCompat_MackerelMonitorResource/service_metric
=== PAUSE TestAccCompat_MackerelMonitorResource/service_metric
=== RUN   TestAccCompat_MackerelMonitorResource/external/empty
=== PAUSE TestAccCompat_MackerelMonitorResource/external/empty
=== RUN   TestAccCompat_MackerelMonitorResource/anomaly_detection
=== PAUSE TestAccCompat_MackerelMonitorResource/anomaly_detection
=== CONT  TestAccCompat_MackerelMonitorResource/host_metric/undefined
=== CONT  TestAccCompat_MackerelMonitorResource/query
=== CONT  TestAccCompat_MackerelMonitorResource/external
=== CONT  TestAccCompat_MackerelMonitorResource/connectivity/null
=== CONT  TestAccCompat_MackerelMonitorResource/anomaly_detection
=== CONT  TestAccCompat_MackerelMonitorResource/connectivity/empty
=== CONT  TestAccCompat_MackerelMonitorResource/service_metric
=== CONT  TestAccCompat_MackerelMonitorResource/external/empty
=== CONT  TestAccCompat_MackerelMonitorResource/host_metric/null
=== CONT  TestAccCompat_MackerelMonitorResource/connectivity/undefined
=== CONT  TestAccCompat_MackerelMonitorResource/host_metric/empty
=== CONT  TestAccCompat_MackerelMonitorResource/expression
=== CONT  TestAccCompat_MackerelMonitorResource/external/null
--- PASS: TestAccCompat_MackerelMonitorResource (0.00s)
    --- PASS: TestAccCompat_MackerelMonitorResource/external (9.60s)
    --- PASS: TestAccCompat_MackerelMonitorResource/host_metric/undefined (9.67s)
    --- PASS: TestAccCompat_MackerelMonitorResource/host_metric/null (9.67s)
    --- PASS: TestAccCompat_MackerelMonitorResource/connectivity/undefined (9.68s)
    --- PASS: TestAccCompat_MackerelMonitorResource/connectivity/null (9.77s)
    --- PASS: TestAccCompat_MackerelMonitorResource/external/empty (9.77s)
    --- PASS: TestAccCompat_MackerelMonitorResource/query (9.85s)
    --- PASS: TestAccCompat_MackerelMonitorResource/connectivity/empty (9.87s)
    --- PASS: TestAccCompat_MackerelMonitorResource/service_metric (10.02s)
    --- PASS: TestAccCompat_MackerelMonitorResource/anomaly_detection (10.41s)
    --- PASS: TestAccCompat_MackerelMonitorResource/host_metric/empty (7.41s)
    --- PASS: TestAccCompat_MackerelMonitorResource/expression (7.54s)
    --- PASS: TestAccCompat_MackerelMonitorResource/external/null (7.54s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider        17.789s
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/typeutil        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/validatorutil   (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel 0.740s [no tests to run]
...
```
