### PR TITLE
Fix monitor schema in framework implementation

### DIFF
--- a/internal/provider/resource_mackerel_monitor.go
+++ b/internal/provider/resource_mackerel_monitor.go
@@ -637,7 +637,11 @@ func schemaMonitorResourceAnomalyDetectionBlock() schema.Block {
 					Computed:    true,
 					Default:     int64default.StaticInt64(0),
 				},
-				"scopes": schemaMonitorResourceScopesAttr(),
+				"scopes": schema.SetAttribute{
+					ElementType: types.StringType,
+					Description: schemaMonitorScopesDesc,
+					Required:    true,
+				},
 			},
 			Validators: []validator.Object{
 				objectvalidator.AtLeastOneOf(path.MatchRoot("warning_sensitivity"), path.MatchRoot("critical_sensitivity")),


### PR DESCRIPTION
In SDK implementation, `mackerel_monitor.anomaly_detection.scopes` is required: https://github.com/mackerelio-labs/terraform-provider-mackerel/blob/7586ebbf5ea3a5966ce69880093798ea8bf573db/mackerel/resource_mackerel_monitor.go?plain=1#L332-L336

But in framework implementation, it is a optional attribute. This PR makes it required.

Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS='AccMackerelMonitor'
TF_ACC=1 go test -v ./... -run AccMackerelMonitor -timeout 120m
?       github.com/mackerelio-labs/terraform-provider-mackerel  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel        0.277s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/planmodifierutil        0.426s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider        0.795s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/typeutil        0.454s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/validatorutil   0.282s [no tests to run]
=== RUN   TestAccMackerelMonitor_HostMetric
=== PAUSE TestAccMackerelMonitor_HostMetric
=== RUN   TestAccMackerelMonitor_Connectivity
=== PAUSE TestAccMackerelMonitor_Connectivity
=== RUN   TestAccMackerelMonitor_ServiceMetric
=== PAUSE TestAccMackerelMonitor_ServiceMetric
=== RUN   TestAccMackerelMonitor_External
=== PAUSE TestAccMackerelMonitor_External
=== RUN   TestAccMackerelMonitor_Expression
=== PAUSE TestAccMackerelMonitor_Expression
=== RUN   TestAccMackerelMonitor_AnomalyDetection
=== PAUSE TestAccMackerelMonitor_AnomalyDetection
=== RUN   TestAccMackerelMonitor_Query
=== PAUSE TestAccMackerelMonitor_Query
=== CONT  TestAccMackerelMonitor_HostMetric
=== CONT  TestAccMackerelMonitor_Expression
=== CONT  TestAccMackerelMonitor_Query
=== CONT  TestAccMackerelMonitor_ServiceMetric
=== CONT  TestAccMackerelMonitor_Connectivity
=== CONT  TestAccMackerelMonitor_External
=== CONT  TestAccMackerelMonitor_AnomalyDetection
--- PASS: TestAccMackerelMonitor_Expression (5.87s)
--- PASS: TestAccMackerelMonitor_ServiceMetric (6.21s)
--- PASS: TestAccMackerelMonitor_HostMetric (6.50s)
--- PASS: TestAccMackerelMonitor_Connectivity (6.51s)
--- PASS: TestAccMackerelMonitor_Query (6.54s)
--- PASS: TestAccMackerelMonitor_AnomalyDetection (6.55s)
--- PASS: TestAccMackerelMonitor_External (6.61s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel 7.746s
...
```
