### PR TITLE
Add expected_status_code to the external monitor resource and data source.

### DIFF
--- a/docs/data-sources/monitor.md
+++ b/docs/data-sources/monitor.md
@@ -63,6 +63,7 @@ data "mackerel_monitor" "this" {
   * `headers` - The values configured as the HTTP request header.
   * `max_check_attempts` - Number of consecutive Warning/Critical counts before an alert is made.
   * `follow_redirect` - Evaluates the response of the redirector as a result.
+  * `expected_status_code` - Expected http status code of the response.
 * `expression` -  The settings for the monitor of expression monitoring.
   * `expression` - Expression of the monitoring target.
   * `operator` - The comparison operator to determines the conditions that state whether the designated variable is either big or small. The observed value is on the left of the operator and the designated value is on the right.

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -179,6 +179,7 @@ The following arguments are required:
 * `headers` - The values configured as the HTTP request header.
 * `max_check_attempts` - Number of consecutive Warning/Critical counts before an alert is made. Default is `1`. Valid values are numbers `1` through `10` inclusive.
 * `follow_redirect` - Evaluates the response of the redirector as a result. Valid values are `true` and `false`. Default is `false`.
+* `expected_status_code` - Expected http status code of the response.
 
 ### expression
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.16.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
 	github.com/hashicorp/terraform-plugin-testing v1.9.0
-	github.com/mackerelio/mackerel-client-go v0.33.0
+	github.com/mackerelio/mackerel-client-go v0.36.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -426,8 +426,8 @@ github.com/leonklingele/grouper v1.1.0/go.mod h1:uk3I3uDfi9B6PeUjsCKi6ndcf63Uy7s
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lufeee/execinquery v1.2.1 h1:hf0Ems4SHcUGBxpGN7Jz78z1ppVkP/837ZlETPCEtOM=
 github.com/lufeee/execinquery v1.2.1/go.mod h1:EC7DrEKView09ocscGHC+apXMIaorh4xqSxS/dy8SbM=
-github.com/mackerelio/mackerel-client-go v0.33.0 h1:dMv0pyR3Exvtxxq3l7xzGF6D/5ky2Jgftzmp4aAoFYg=
-github.com/mackerelio/mackerel-client-go v0.33.0/go.mod h1:b4qVMQi+w4rxtKQIFycLWXNBtIi9d0r571RzYmg/aXo=
+github.com/mackerelio/mackerel-client-go v0.36.0 h1:/dLedCmGWpo1cIKi5BB8QYtbA8w/R8McieleQ+Vme8w=
+github.com/mackerelio/mackerel-client-go v0.36.0/go.mod h1:EJom2FXbK0Akv61dVsRiH9oKggk4IWlgb6hrQtGK1Z4=
 github.com/magiconair/properties v1.8.6 h1:5ibWZ6iY0NctNGWo87LalDlEZ6R41TqbbDamhfG/Qzo=
 github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/maratori/testableexamples v1.0.0 h1:dU5alXRrD8WKSjOUnmJZuzdxWOEQ57+7s93SLMxb2vI=

--- a/internal/mackerel/monitor.go
+++ b/internal/mackerel/monitor.go
@@ -88,6 +88,7 @@ type MonitorExternal struct {
 	SkipCertificateVerification     types.Bool        `tfsdk:"skip_certificate_verification"`
 	Headers                         map[string]string `tfsdk:"headers"`
 	FollowRedirect                  types.Bool        `tfsdk:"follow_redirect"`
+	ExpectedStatusCode              types.Int64       `tfsdk:"expected_status_code"`
 }
 
 type MonitorAnomalyDetection struct {
@@ -417,6 +418,10 @@ func (m MonitorModel) mackerelMonitor() mackerel.Monitor {
 		if certExpWarn := ehm.CertificationExpirationWarning.ValueInt64(); certExpWarn > 0 {
 			certExpWarnU64 := uint64(certExpWarn)
 			mon.CertificationExpirationWarning = &certExpWarnU64
+		}
+		if expectedStatusCode := ehm.ExpectedStatusCode.ValueInt64(); expectedStatusCode > 0 {
+			expectedStatusCode := int(expectedStatusCode)
+			mon.ExpectedStatusCode = &expectedStatusCode
 		}
 
 		// Headers

--- a/internal/mackerel/monitor_test.go
+++ b/internal/mackerel/monitor_test.go
@@ -346,6 +346,7 @@ func Test_Monitor_toModel(t *testing.T) {
 					SkipCertificateVerification:     types.BoolValue(false),
 					Headers:                         nil,
 					FollowRedirect:                  types.BoolValue(false),
+					ExpectedStatusCode:              types.Int64Value(200),
 				}},
 			},
 		},

--- a/mackerel/data_source_mackerel_monitor.go
+++ b/mackerel/data_source_mackerel_monitor.go
@@ -205,6 +205,10 @@ func dataSourceMackerelMonitor() *schema.Resource {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
+						"expected_status_code": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/mackerel/resource_mackerel_monitor.go
+++ b/mackerel/resource_mackerel_monitor.go
@@ -266,6 +266,10 @@ func resourceMackerelMonitor() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+						"expected_status_code": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -566,6 +570,10 @@ func expandMonitorExternalHTTP(d *schema.ResourceData) *mackerel.MonitorExternal
 	if certificationExpirationWarning, ok := d.GetOkExists("external.0.certification_expiration_warning"); ok {
 		certificationExpirationWarning := uint64(certificationExpirationWarning.(int))
 		monitor.CertificationExpirationWarning = &certificationExpirationWarning
+	}
+	if expectedStatusCode, ok := d.GetOkExists("external.0.expected_status_code"); ok {
+		expectedStatusCode := expectedStatusCode.(int)
+		monitor.ExpectedStatusCode = &expectedStatusCode
 	}
 	if headers, ok := d.GetOk("external.0.headers"); ok {
 		for name, value := range headers.(map[string]interface{}) {

--- a/mackerel/resource_mackerel_monitor.go
+++ b/mackerel/resource_mackerel_monitor.go
@@ -549,6 +549,7 @@ func expandMonitorExternalHTTP(d *schema.ResourceData) *mackerel.MonitorExternal
 		SkipCertificateVerification:     d.Get("external.0.skip_certificate_verification").(bool),
 		Headers:                         []mackerel.HeaderField{},
 		FollowRedirect:                  d.Get("external.0.follow_redirect").(bool),
+		ExpectedStatusCode:              nil,
 	}
 
 	if responseTimeCritical, ok := d.GetOkExists("external.0.response_time_critical"); ok {
@@ -573,7 +574,9 @@ func expandMonitorExternalHTTP(d *schema.ResourceData) *mackerel.MonitorExternal
 	}
 	if expectedStatusCode, ok := d.GetOkExists("external.0.expected_status_code"); ok {
 		expectedStatusCode := expectedStatusCode.(int)
-		monitor.ExpectedStatusCode = &expectedStatusCode
+		if expectedStatusCode > 0 {
+			monitor.ExpectedStatusCode = &expectedStatusCode
+		}
 	}
 	if headers, ok := d.GetOk("external.0.headers"); ok {
 		for name, value := range headers.(map[string]interface{}) {

--- a/mackerel/structure_flattens.go
+++ b/mackerel/structure_flattens.go
@@ -166,6 +166,7 @@ func flattenMonitorExternalHTTP(monitor *mackerel.MonitorExternalHTTP, d *schema
 		"skip_certificate_verification":     monitor.SkipCertificateVerification,
 		"headers":                           headers,
 		"follow_redirect":                   monitor.FollowRedirect,
+		"expected_status_code":              monitor.ExpectedStatusCode,
 	}
 	d.Set("external", []map[string]interface{}{external})
 	return diags


### PR DESCRIPTION
Hi.

This PR adds `expected_status_code` into the `mackerel_monitor` resource and data source.

See also [外形監視でOKと判定するHTTPステータスコードを選択可能にしました
](https://mackerel.io/ja/blog/entry/weekly/20241203#%E5%A4%96%E5%BD%A2%E7%9B%A3%E8%A6%96%E3%81%A7OK%E3%81%A8%E5%88%A4%E5%AE%9A%E3%81%99%E3%82%8BHTTP%E3%82%B9%E3%83%86%E3%83%BC%E3%82%BF%E3%82%B9%E3%82%B3%E3%83%BC%E3%83%89%E3%82%92%E9%81%B8%E6%8A%9E%E5%8F%AF%E8%83%BD%E3%81%AB%E3%81%97%E3%81%BE%E3%81%97%E3%81%9F)

Output from acceptance testing:

```console
$ make testacc TESTS='Monitor.?External'
TF_ACC=1 go test -v ./... -run Monitor.?External -timeout 120m
?       github.com/mackerelio-labs/terraform-provider-mackerel  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel        0.008s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/planmodifierutil        0.009s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider        0.013s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/typeutil        0.007s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/validatorutil   0.004s [no tests to run]
=== RUN   TestAccDataSourceMackerelMonitorExternal
=== PAUSE TestAccDataSourceMackerelMonitorExternal
=== RUN   TestAccMackerelMonitor_External
=== PAUSE TestAccMackerelMonitor_External
=== CONT  TestAccDataSourceMackerelMonitorExternal
=== CONT  TestAccMackerelMonitor_External
--- PASS: TestAccDataSourceMackerelMonitorExternal (1.82s)
--- PASS: TestAccMackerelMonitor_External (3.14s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel 3.151s
```

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS=TestAccXXX

...
```
