### PR TITLE
Add external_status_code support to internal provider resource

### DIFF
--- a/internal/mackerel/monitor.go
+++ b/internal/mackerel/monitor.go
@@ -261,6 +261,9 @@ func newMonitor(mackerelMonitor mackerel.Monitor) (MonitorModel, error) {
 		} else /* default */ {
 			ehm.CertificationExpirationWarning = types.Int64Value(0)
 		}
+		if m.ExpectedStatusCode != nil {
+			ehm.ExpectedStatusCode = types.Int64Value(int64(*m.ExpectedStatusCode))
+		}
 
 		if m.Headers != nil {
 			headers := make(map[string]string, len(m.Headers))

--- a/internal/mackerel/monitor_test.go
+++ b/internal/mackerel/monitor_test.go
@@ -346,7 +346,6 @@ func Test_Monitor_toModel(t *testing.T) {
 					SkipCertificateVerification:     types.BoolValue(false),
 					Headers:                         nil,
 					FollowRedirect:                  types.BoolValue(false),
-					ExpectedStatusCode:              types.Int64Value(200),
 				}},
 			},
 		},
@@ -375,6 +374,7 @@ func Test_Monitor_toModel(t *testing.T) {
 				Headers: []mackerel.HeaderField{
 					{Name: "Cache-Control", Value: "no-cache"},
 				},
+				ExpectedStatusCode: toPtr(200),
 			},
 			wants: MonitorModel{
 				ID:                   types.StringValue("5dQKsiUxvf9"),
@@ -399,7 +399,8 @@ func Test_Monitor_toModel(t *testing.T) {
 					Headers: map[string]string{
 						"Cache-Control": "no-cache",
 					},
-					FollowRedirect: types.BoolValue(true),
+					FollowRedirect:     types.BoolValue(true),
+					ExpectedStatusCode: types.Int64Value(200),
 				}},
 			},
 		},
@@ -941,4 +942,8 @@ func float64Pointer(f float64) *float64 {
 
 func uint64Pointer(u64 uint64) *uint64 {
 	return &u64
+}
+
+func toPtr[T any](x T) *T {
+	return &x
 }

--- a/internal/provider/resource_mackerel_monitor.go
+++ b/internal/provider/resource_mackerel_monitor.go
@@ -494,6 +494,7 @@ const (
 	schemaMonitorExternal_SkipCertificateVerificationDesc     = "Whether or not to skip the verification of certificate."
 	schemaMonitorExternal_CertificationExpirationCriticalDesc = "The threshold (in days) of the certification expiration date for critical alerts."
 	schemaMonitorExternal_CertificationExpirationWarningDesc  = "The threshold (in days) of the certification expiration date for warning alerts."
+	schemaMonitorExternal_ExpectedStatusCodeDesc              = "Specify the status code that is judged as OK. If not specified, 2xx or 3xx will be judged as OK."
 )
 
 func schemaMonitorResourceExternalBlock() schema.Block {
@@ -599,6 +600,10 @@ func schemaMonitorResourceExternalBlock() schema.Block {
 					Optional:    true,
 					Computed:    true,
 					Default:     int64default.StaticInt64(0),
+				},
+				"expected_status_code": schema.Int64Attribute{
+					Description: schemaMonitorExternal_ExpectedStatusCodeDesc,
+					Optional:    true,
 				},
 			},
 		},

--- a/internal/provider/resource_mackerel_monitor_test.go
+++ b/internal/provider/resource_mackerel_monitor_test.go
@@ -122,7 +122,7 @@ resource "mackerel_monitor" "service_metric" {
   name = "` + name + `"
   service_metric {
     service = mackerel_service.svc.name
-    duration = 1	
+    duration = 1
     metric = "custom.access.2xx_ratio"
     operator = ">"
     warning = "99.9"

--- a/mackerel/resource_mackerel_monitor_test.go
+++ b/mackerel/resource_mackerel_monitor_test.go
@@ -314,6 +314,7 @@ func TestAccMackerelMonitor_External(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "external.0.headers.%", "1"),
 						resource.TestCheckResourceAttr(resourceName, "external.0.headers.Cache-Control", "no-cache"),
 						resource.TestCheckResourceAttr(resourceName, "external.0.follow_redirect", "true"),
+						resource.TestCheckResourceAttr(resourceName, "external.0.expected_status_code", "200"),
 					),
 					resource.TestCheckResourceAttr(resourceName, "expression.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "anomaly_detection.#", "0"),
@@ -766,6 +767,7 @@ resource "mackerel_monitor" "foo" {
       Cache-Control = "no-cache"
     }
     follow_redirect = true
+		expected_status_code = 200
   }
 }
 `, serviceName, name)


### PR DESCRIPTION
Added support for external_status_code in external monitor in https://github.com/mackerelio-labs/terraform-provider-mackerel/pull/258 . However, the implementation was missing and the test failed like https://github.com/mackerelio-labs/terraform-provider-mackerel/actions/runs/14212042760/job/39821559851 .

Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS=TestAccCompat_MackerelMonitorResource
=== RUN   TestAccCompat_MackerelMonitorResource
=== PAUSE TestAccCompat_MackerelMonitorResource
=== CONT  TestAccCompat_MackerelMonitorResource
=== RUN   TestAccCompat_MackerelMonitorResource/host_metric/undefined
=== PAUSE TestAccCompat_MackerelMonitorResource/host_metric/undefined
=== RUN   TestAccCompat_MackerelMonitorResource/connectivity/undefined
=== PAUSE TestAccCompat_MackerelMonitorResource/connectivity/undefined
=== RUN   TestAccCompat_MackerelMonitorResource/connectivity/null
=== PAUSE TestAccCompat_MackerelMonitorResource/connectivity/null
=== RUN   TestAccCompat_MackerelMonitorResource/external
=== PAUSE TestAccCompat_MackerelMonitorResource/external
=== RUN   TestAccCompat_MackerelMonitorResource/expression
=== PAUSE TestAccCompat_MackerelMonitorResource/expression
=== RUN   TestAccCompat_MackerelMonitorResource/query
=== PAUSE TestAccCompat_MackerelMonitorResource/query
=== RUN   TestAccCompat_MackerelMonitorResource/host_metric/null
=== PAUSE TestAccCompat_MackerelMonitorResource/host_metric/null
=== RUN   TestAccCompat_MackerelMonitorResource/host_metric/empty
=== PAUSE TestAccCompat_MackerelMonitorResource/host_metric/empty
=== RUN   TestAccCompat_MackerelMonitorResource/connectivity/empty
=== PAUSE TestAccCompat_MackerelMonitorResource/connectivity/empty
=== RUN   TestAccCompat_MackerelMonitorResource/service_metric
=== PAUSE TestAccCompat_MackerelMonitorResource/service_metric
=== RUN   TestAccCompat_MackerelMonitorResource/external/null
=== PAUSE TestAccCompat_MackerelMonitorResource/external/null
=== RUN   TestAccCompat_MackerelMonitorResource/external/empty
=== PAUSE TestAccCompat_MackerelMonitorResource/external/empty
=== RUN   TestAccCompat_MackerelMonitorResource/anomaly_detection
=== PAUSE TestAccCompat_MackerelMonitorResource/anomaly_detection
=== CONT  TestAccCompat_MackerelMonitorResource/host_metric/undefined
=== CONT  TestAccCompat_MackerelMonitorResource/host_metric/empty
=== CONT  TestAccCompat_MackerelMonitorResource/external/null
=== CONT  TestAccCompat_MackerelMonitorResource/service_metric
=== CONT  TestAccCompat_MackerelMonitorResource/connectivity/empty
=== CONT  TestAccCompat_MackerelMonitorResource/expression
=== CONT  TestAccCompat_MackerelMonitorResource/anomaly_detection
=== CONT  TestAccCompat_MackerelMonitorResource/connectivity/null
=== CONT  TestAccCompat_MackerelMonitorResource/host_metric/null
=== CONT  TestAccCompat_MackerelMonitorResource/connectivity/undefined
=== CONT  TestAccCompat_MackerelMonitorResource/external
=== CONT  TestAccCompat_MackerelMonitorResource/query
=== CONT  TestAccCompat_MackerelMonitorResource/external/empty
--- PASS: TestAccCompat_MackerelMonitorResource (0.00s)
    --- PASS: TestAccCompat_MackerelMonitorResource/external (4.25s)
    --- PASS: TestAccCompat_MackerelMonitorResource/expression (4.30s)
    --- PASS: TestAccCompat_MackerelMonitorResource/external/null (4.32s)
    --- PASS: TestAccCompat_MackerelMonitorResource/connectivity/empty (4.41s)
    --- PASS: TestAccCompat_MackerelMonitorResource/host_metric/undefined (4.43s)
    --- PASS: TestAccCompat_MackerelMonitorResource/host_metric/null (4.43s)
    --- PASS: TestAccCompat_MackerelMonitorResource/connectivity/null (4.46s)
    --- PASS: TestAccCompat_MackerelMonitorResource/host_metric/empty (4.48s)
    --- PASS: TestAccCompat_MackerelMonitorResource/connectivity/undefined (4.50s)
    --- PASS: TestAccCompat_MackerelMonitorResource/query (4.58s)
    --- PASS: TestAccCompat_MackerelMonitorResource/service_metric (4.74s)
    --- PASS: TestAccCompat_MackerelMonitorResource/anomaly_detection (5.07s)
    --- PASS: TestAccCompat_MackerelMonitorResource/external/empty (2.91s)
PASS

$ make testacc TESTS=TestAccMackerelMonitor_External
=== RUN   TestAccMackerelMonitor_External
=== PAUSE TestAccMackerelMonitor_External
=== CONT  TestAccMackerelMonitor_External
--- PASS: TestAccMackerelMonitor_External (3.55s)
PASS

$ make testacc TESTS=TestAccDataSourceMackerelMonitorExternal
=== RUN   TestAccDataSourceMackerelMonitorExternal
=== PAUSE TestAccDataSourceMackerelMonitorExternal
=== CONT  TestAccDataSourceMackerelMonitorExternal
--- PASS: TestAccDataSourceMackerelMonitorExternal (1.94s)
PASS
```
