### PR TITLE
fix monitor data source

### DIFF
--- a/internal/provider/data_source_mackerel_monitor.go
+++ b/internal/provider/data_source_mackerel_monitor.go
@@ -145,8 +145,9 @@ func (d *mackerelMonitorDataSource) Schema(_ context.Context, _ datasource.Schem
 						"response_time_warning":  types.Float64Type,
 						"response_time_duration": types.Int64Type,
 
-						"contains_string": types.StringType,
-						"follow_redirect": types.BoolType,
+						"contains_string":      types.StringType,
+						"follow_redirect":      types.BoolType,
+						"expected_status_code": types.Int64Type,
 
 						"skip_certificate_verification":     types.BoolType,
 						"certification_expiration_critical": types.Int64Type,

--- a/mackerel/data_source_mackerel_monitor_test.go
+++ b/mackerel/data_source_mackerel_monitor_test.go
@@ -163,6 +163,7 @@ func TestAccDataSourceMackerelMonitorExternal(t *testing.T) {
 						resource.TestCheckResourceAttr(dsName, "external.0.headers.%", "1"),
 						resource.TestCheckResourceAttr(dsName, "external.0.headers.Cache-Control", "no-cache"),
 						resource.TestCheckResourceAttr(dsName, "external.0.follow_redirect", "true"),
+						resource.TestCheckResourceAttr(dsName, "external.0.expected_status_code", "200"),
 					),
 					resource.TestCheckResourceAttr(dsName, "expression.#", "0"),
 					resource.TestCheckResourceAttr(dsName, "anomaly_detection.#", "0"),
@@ -430,6 +431,7 @@ resource "mackerel_monitor" "foo" {
       Cache-Control = "no-cache"
     }
     follow_redirect = true
+    expected_status_code = 200
   }
 }
 

--- a/mackerel/resource_mackerel_monitor_test.go
+++ b/mackerel/resource_mackerel_monitor_test.go
@@ -767,7 +767,7 @@ resource "mackerel_monitor" "foo" {
       Cache-Control = "no-cache"
     }
     follow_redirect = true
-		expected_status_code = 200
+    expected_status_code = 200
   }
 }
 `, serviceName, name)


### PR DESCRIPTION
Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ go clean -testcache
$ MACKEREL_EXPERIMENTAL_TFFRAMEWORK=1 make testacc TESTS=TestAccDataSourceMackerelMonitorExternal
TF_ACC=1 go test -v ./... -run TestAccDataSourceMackerelMonitorExternal -timeout 120m
?       github.com/mackerelio-labs/terraform-provider-mackerel  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel        0.384s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/planmodifierutil        0.210s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider        0.499s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/typeutil        0.211s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/validatorutil   0.564s [no tests to run]
2025/04/03 23:51:31 [INFO] mackerel: use terraform-plugin-framework based implementation
=== RUN   TestAccDataSourceMackerelMonitorExternal
=== PAUSE TestAccDataSourceMackerelMonitorExternal
=== CONT  TestAccDataSourceMackerelMonitorExternal
--- PASS: TestAccDataSourceMackerelMonitorExternal (2.61s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel 3.504s
$ go clean -testcache
$ MACKEREL_EXPERIMENTAL_TFFRAMEWORK=0 make testacc TESTS=TestAccDataSourceMackerelMonitorExternal
TF_ACC=1 go test -v ./... -run TestAccDataSourceMackerelMonitorExternal -timeout 120m
?       github.com/mackerelio-labs/terraform-provider-mackerel  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel        0.389s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/planmodifierutil        0.203s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider        0.612s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/typeutil        0.328s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/validatorutil   0.683s [no tests to run]
=== RUN   TestAccDataSourceMackerelMonitorExternal
=== PAUSE TestAccDataSourceMackerelMonitorExternal
=== CONT  TestAccDataSourceMackerelMonitorExternal
--- PASS: TestAccDataSourceMackerelMonitorExternal (2.18s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel 3.153s
$
```
