### PR TITLE
add roles attribute to service data source and resource

### DIFF
--- a/docs/data-sources/service.md
+++ b/docs/data-sources/service.md
@@ -25,4 +25,4 @@ data "mackerel_service" "foo" {
 In addition to all arguments above, the following attributes are exported:
 
 * `memo` - Notes related to this service.
-* `roles` - List of roles in the service.
+* `roles` - Set of roles in the service.

--- a/docs/data-sources/service.md
+++ b/docs/data-sources/service.md
@@ -25,3 +25,4 @@ data "mackerel_service" "foo" {
 In addition to all arguments above, the following attributes are exported:
 
 * `memo` - Notes related to this service.
+* `roles` - List of roles in the service.

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -23,7 +23,9 @@ resource "mackerel_service" "foo" {
 
 ## Attributes Reference
 
-No additional attributes are exported.
+In addition to all arguments above, the following attributes are exported:
+
+* `roles` - List of roles in the service. This is a computed field and will be populated after the service is created.
 
 ## Import
 

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -25,7 +25,7 @@ resource "mackerel_service" "foo" {
 
 In addition to all arguments above, the following attributes are exported:
 
-* `roles` - List of roles in the service. This is a computed field and will be populated after the service is created.
+* `roles` - Set of roles in the service. This is a computed field and will be populated after the service is created.
 
 ## Import
 

--- a/internal/mackerel/service.go
+++ b/internal/mackerel/service.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mackerelio/mackerel-client-go"
@@ -25,10 +26,10 @@ func ServiceNameValidator() validator.String {
 type ServiceModel = ServiceModelV0
 
 type ServiceModelV0 struct {
-	ID    types.String   `tfsdk:"id"`
-	Name  string         `tfsdk:"name"`
-	Memo  types.String   `tfsdk:"memo"`
-	Roles []types.String `tfsdk:"roles"`
+	ID    types.String `tfsdk:"id"`
+	Name  string       `tfsdk:"name"`
+	Memo  types.String `tfsdk:"memo"`
+	Roles types.Set    `tfsdk:"roles"`
 }
 
 func ImportService(_ context.Context, id string) (ServiceModel, error) {
@@ -62,10 +63,11 @@ func readServiceInner(client serviceFinder, name string) (ServiceModel, error) {
 	}
 
 	service := services[serviceIdx]
-	roles := make([]types.String, len(service.Roles))
+	elms := make([]attr.Value, len(service.Roles))
 	for i, role := range service.Roles {
-		roles[i] = types.StringValue(role)
+		elms[i] = types.StringValue(role)
 	}
+	roles, _ := types.SetValue(types.StringType, elms)
 	return ServiceModelV0{
 		ID:    types.StringValue(service.Name),
 		Name:  service.Name,

--- a/internal/mackerel/service.go
+++ b/internal/mackerel/service.go
@@ -25,9 +25,10 @@ func ServiceNameValidator() validator.String {
 type ServiceModel = ServiceModelV0
 
 type ServiceModelV0 struct {
-	ID   types.String `tfsdk:"id"`
-	Name string       `tfsdk:"name"`
-	Memo types.String `tfsdk:"memo"`
+	ID    types.String   `tfsdk:"id"`
+	Name  string         `tfsdk:"name"`
+	Memo  types.String   `tfsdk:"memo"`
+	Roles []types.String `tfsdk:"roles"`
 }
 
 func ImportService(_ context.Context, id string) (ServiceModel, error) {
@@ -61,10 +62,15 @@ func readServiceInner(client serviceFinder, name string) (ServiceModel, error) {
 	}
 
 	service := services[serviceIdx]
+	roles := make([]types.String, len(service.Roles))
+	for i, role := range service.Roles {
+		roles[i] = types.StringValue(role)
+	}
 	return ServiceModelV0{
-		ID:   types.StringValue(service.Name),
-		Name: service.Name,
-		Memo: types.StringValue(service.Memo),
+		ID:    types.StringValue(service.Name),
+		Name:  service.Name,
+		Memo:  types.StringValue(service.Memo),
+		Roles: roles,
 	}, nil
 }
 

--- a/internal/mackerel/service.go
+++ b/internal/mackerel/service.go
@@ -34,8 +34,10 @@ type ServiceModelV0 struct {
 
 func ImportService(_ context.Context, id string) (ServiceModel, error) {
 	return ServiceModelV0{
-		ID:   types.StringValue(id),
-		Name: id,
+		ID:    types.StringValue(id),
+		Name:  id,
+		Memo:  types.StringValue(""),
+		Roles: types.SetValueMust(types.StringType, []attr.Value{}),
 	}, nil
 }
 

--- a/internal/mackerel/service_test.go
+++ b/internal/mackerel/service_test.go
@@ -78,30 +78,35 @@ func Test_ReadService(t *testing.T) {
 			inClient: func() ([]*mackerel.Service, error) {
 				return []*mackerel.Service{
 					{
-						Name: "service0",
+						Name:  "service0",
+						Roles: []string{},
 					},
 					{
-						Name: "service1",
-						Memo: "memo",
+						Name:  "service1",
+						Memo:  "memo",
+						Roles: []string{},
 					},
 				}, nil
 			},
 			inName: "service1",
 			want: ServiceModelV0{
-				ID:   types.StringValue("service1"),
-				Name: "service1",
-				Memo: types.StringValue("memo"),
+				ID:    types.StringValue("service1"),
+				Name:  "service1",
+				Memo:  types.StringValue("memo"),
+				Roles: []types.String{},
 			},
 		},
 		"no service": {
 			inClient: func() ([]*mackerel.Service, error) {
 				return []*mackerel.Service{
 					{
-						Name: "service0",
+						Name:  "service0",
+						Roles: []string{},
 					},
 					{
-						Name: "service1",
-						Memo: "memo",
+						Name:  "service1",
+						Memo:  "memo",
+						Roles: []string{},
 					},
 				}, nil
 			},

--- a/internal/mackerel/service_test.go
+++ b/internal/mackerel/service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -79,21 +80,23 @@ func Test_ReadService(t *testing.T) {
 				return []*mackerel.Service{
 					{
 						Name:  "service0",
-						Roles: []string{},
+						Roles: []string{"foo", "bar"},
 					},
 					{
 						Name:  "service1",
 						Memo:  "memo",
-						Roles: []string{},
+						Roles: []string{"baz"},
 					},
 				}, nil
 			},
 			inName: "service1",
 			want: ServiceModelV0{
-				ID:    types.StringValue("service1"),
-				Name:  "service1",
-				Memo:  types.StringValue("memo"),
-				Roles: []types.String{},
+				ID:   types.StringValue("service1"),
+				Name: "service1",
+				Memo: types.StringValue("memo"),
+				Roles: types.SetValueMust(types.StringType, []attr.Value{
+					types.StringValue("baz"),
+				}),
 			},
 		},
 		"no service": {

--- a/internal/provider/data_source_mackerel_service.go
+++ b/internal/provider/data_source_mackerel_service.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel"
 )
 
@@ -41,6 +42,11 @@ func (d *mackerelServiceDataSource) Schema(_ context.Context, _ datasource.Schem
 			"memo": schema.StringAttribute{
 				Computed:    true,
 				Description: "Notes related to this service.",
+			},
+			"roles": schema.ListAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+				Description: "List of roles in the service.",
 			},
 		},
 	}

--- a/internal/provider/data_source_mackerel_service.go
+++ b/internal/provider/data_source_mackerel_service.go
@@ -43,10 +43,10 @@ func (d *mackerelServiceDataSource) Schema(_ context.Context, _ datasource.Schem
 				Computed:    true,
 				Description: "Notes related to this service.",
 			},
-			"roles": schema.ListAttribute{
+			"roles": schema.SetAttribute{
 				Computed:    true,
 				ElementType: types.StringType,
-				Description: "List of roles in the service.",
+				Description: "Set of roles in the service.",
 			},
 		},
 	}

--- a/internal/provider/resource_mackerel_service.go
+++ b/internal/provider/resource_mackerel_service.go
@@ -60,10 +60,10 @@ func (r *mackerelServiceResource) Schema(_ context.Context, _ resource.SchemaReq
 				},
 				Default: stringdefault.StaticString(""),
 			},
-			"roles": schema.ListAttribute{
+			"roles": schema.SetAttribute{
 				Computed:    true,
 				ElementType: types.StringType,
-				Description: "List of roles in the service. This is a computed field and will be populated after the service is created.",
+				Description: "Set of roles in the service. This is a computed field and will be populated after the service is created.",
 			},
 		},
 	}

--- a/internal/provider/resource_mackerel_service.go
+++ b/internal/provider/resource_mackerel_service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel"
 )
 
@@ -59,6 +60,11 @@ func (r *mackerelServiceResource) Schema(_ context.Context, _ resource.SchemaReq
 				},
 				Default: stringdefault.StaticString(""),
 			},
+			"roles": schema.ListAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+				Description: "List of roles in the service. This is a computed field and will be populated after the service is created.",
+			},
 		},
 	}
 }
@@ -82,6 +88,15 @@ func (r *mackerelServiceResource) Create(ctx context.Context, req resource.Creat
 	if err := data.Create(ctx, r.Client); err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to create Service",
+			err.Error(),
+		)
+		return
+	}
+
+	// Read back the full service data to get the roles field
+	if err := data.Read(ctx, r.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to read Service after creation",
 			err.Error(),
 		)
 		return

--- a/mackerel/data_source_mackerel_service.go
+++ b/mackerel/data_source_mackerel_service.go
@@ -21,6 +21,11 @@ func dataSourceMackerelService() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"roles": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
 		},
 	}
 }

--- a/mackerel/data_source_mackerel_service_test.go
+++ b/mackerel/data_source_mackerel_service_test.go
@@ -51,7 +51,7 @@ data "mackerel_service" "foo" {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(name)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(name)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memo"), knownvalue.StringExact("")),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("roles"), knownvalue.ListExact([]knownvalue.Check{})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("roles"), knownvalue.SetExact(nil)),
 				},
 			}}
 		},

--- a/mackerel/data_source_mackerel_service_test.go
+++ b/mackerel/data_source_mackerel_service_test.go
@@ -32,6 +32,7 @@ data "mackerel_service" "foo" {
 					resource.TestCheckResourceAttr(resourceName, "id", name),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "memo", "This service is managed by Terraform."),
+					resource.TestCheckResourceAttr(resourceName, "roles.#", "0"),
 				),
 			}}
 		},
@@ -50,6 +51,7 @@ data "mackerel_service" "foo" {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(name)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(name)),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memo"), knownvalue.StringExact("")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("roles"), knownvalue.ListExact([]knownvalue.Check{})),
 				},
 			}}
 		},

--- a/mackerel/resource_mackerel_service.go
+++ b/mackerel/resource_mackerel_service.go
@@ -34,6 +34,12 @@ func resourceMackerelService() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"roles": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Computed:    true,
+				Description: "List of roles in the service. This is a computed field and will be populated after the service is created.",
+			},
 		},
 	}
 }

--- a/mackerel/resource_mackerel_service.go
+++ b/mackerel/resource_mackerel_service.go
@@ -35,10 +35,11 @@ func resourceMackerelService() *schema.Resource {
 				ForceNew: true,
 			},
 			"roles": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
+				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Computed:    true,
-				Description: "List of roles in the service. This is a computed field and will be populated after the service is created.",
+				Description: "Set of roles in the service. This is a computed field and will be populated after the service is created.",
 			},
 		},
 	}

--- a/mackerel/resource_mackerel_service_test.go
+++ b/mackerel/resource_mackerel_service_test.go
@@ -38,6 +38,7 @@ resource "mackerel_service" "foo" {
 						testAccCheckMackerelServiceExists(resourceName),
 						resource.TestCheckResourceAttr(resourceName, "name", name),
 						resource.TestCheckResourceAttr(resourceName, "memo", memo),
+						resource.TestCheckResourceAttr(resourceName, "roles.#", "0"),
 					),
 				},
 				// Test: Update
@@ -47,6 +48,7 @@ resource "mackerel_service" "foo" {
 						testAccCheckMackerelServiceExists(resourceName),
 						resource.TestCheckResourceAttr(resourceName, "name", nameUpdated),
 						resource.TestCheckResourceAttr(resourceName, "memo", memoUpdated),
+						resource.TestCheckResourceAttr(resourceName, "roles.#", "0"),
 					),
 				},
 				// Test: Import
@@ -76,6 +78,7 @@ resource "mackerel_service" "foo" {
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(name)),
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(name)),
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memo"), knownvalue.StringExact("")),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("roles"), knownvalue.ListExact([]knownvalue.Check{})),
 					},
 				},
 				// Test: Update
@@ -86,6 +89,7 @@ resource "mackerel_service" "foo" {
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(nameUpdated)),
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(nameUpdated)),
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memo"), knownvalue.StringExact("")),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("roles"), knownvalue.ListExact([]knownvalue.Check{})),
 					},
 				},
 				// Test: Import

--- a/mackerel/resource_mackerel_service_test.go
+++ b/mackerel/resource_mackerel_service_test.go
@@ -78,7 +78,7 @@ resource "mackerel_service" "foo" {
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(name)),
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(name)),
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memo"), knownvalue.StringExact("")),
-						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("roles"), knownvalue.ListExact([]knownvalue.Check{})),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("roles"), knownvalue.SetExact(nil)),
 					},
 				},
 				// Test: Update
@@ -89,7 +89,7 @@ resource "mackerel_service" "foo" {
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("id"), knownvalue.StringExact(nameUpdated)),
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(nameUpdated)),
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("memo"), knownvalue.StringExact("")),
-						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("roles"), knownvalue.ListExact([]knownvalue.Check{})),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("roles"), knownvalue.SetExact(nil)),
 					},
 				},
 				// Test: Import

--- a/mackerel/structure_flattens.go
+++ b/mackerel/structure_flattens.go
@@ -12,6 +12,7 @@ import (
 func flattenService(service *mackerel.Service, d *schema.ResourceData) (diags diag.Diagnostics) {
 	d.Set("name", service.Name)
 	d.Set("memo", service.Memo)
+	d.Set("roles", flattenStringList(service.Roles))
 	return diags
 }
 

--- a/mackerel/structure_flattens.go
+++ b/mackerel/structure_flattens.go
@@ -12,7 +12,7 @@ import (
 func flattenService(service *mackerel.Service, d *schema.ResourceData) (diags diag.Diagnostics) {
 	d.Set("name", service.Name)
 	d.Set("memo", service.Memo)
-	d.Set("roles", flattenStringList(service.Roles))
+	d.Set("roles", service.Roles)
 	return diags
 }
 


### PR DESCRIPTION
Hi, I added the computed roles field to both mackerel_service resource and data source.

This enables users to retrieve the role names defined in the service in Terraform.

Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS="TestAcc.*Service$"
TF_ACC=1 go test -v ./... -run TestAcc.*Service$ -timeout 120m
?       github.com/mackerelio-labs/terraform-provider-mackerel  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel        0.007s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/planmodifierutil        0.004s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider        0.010s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/typeutil        0.005s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/validatorutil   0.003s [no tests to run]
=== RUN   TestAccDataSourceMackerelService
=== PAUSE TestAccDataSourceMackerelService
=== RUN   TestAccMackerelService
=== PAUSE TestAccMackerelService
=== CONT  TestAccDataSourceMackerelService
=== RUN   TestAccDataSourceMackerelService/withMemo
=== CONT  TestAccMackerelService
=== RUN   TestAccMackerelService/with_memo
=== PAUSE TestAccDataSourceMackerelService/withMemo
=== RUN   TestAccDataSourceMackerelService/noMemo
=== PAUSE TestAccDataSourceMackerelService/noMemo
=== RUN   TestAccDataSourceMackerelService/not_match_any_service
=== PAUSE TestAccMackerelService/with_memo
=== PAUSE TestAccDataSourceMackerelService/not_match_any_service
=== CONT  TestAccDataSourceMackerelService/withMemo
=== RUN   TestAccMackerelService/no_memo
=== PAUSE TestAccMackerelService/no_memo
=== CONT  TestAccMackerelService/with_memo
=== CONT  TestAccDataSourceMackerelService/not_match_any_service
=== CONT  TestAccDataSourceMackerelService/noMemo
=== CONT  TestAccMackerelService/no_memo
--- PASS: TestAccDataSourceMackerelService (0.00s)
    --- PASS: TestAccDataSourceMackerelService/not_match_any_service (0.47s)
    --- PASS: TestAccDataSourceMackerelService/noMemo (1.49s)
    --- PASS: TestAccDataSourceMackerelService/withMemo (1.57s)
--- PASS: TestAccMackerelService (0.00s)
    --- PASS: TestAccMackerelService/with_memo (2.70s)
    --- PASS: TestAccMackerelService/no_memo (2.88s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel 2.896s
```
