### PR TITLE
Make framework-based implementation the default

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        framework: ['0', '1']
+        implementation: ['sdk', 'framework']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -20,7 +20,7 @@ jobs:
         env:
           TF_ACC: 1
           MACKEREL_API_KEY: ${{ secrets.MACKEREL_API_KEY }}
-          MACKEREL_EXPERIMENTAL_TFFRAMEWORK: ${{ matrix.framework }}
+          MACKEREL_LEGACY_SDK: ${{ matrix.implementation == 'sdk' && '1' || '0' }}
           EXTERNAL_ID: ${{ secrets.EXTERNAL_ID }}
           AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        framework: ['0', '1']
+        implementation: ['sdk', 'framework']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -21,7 +21,7 @@ jobs:
         env:
           TF_ACC: 1
           MACKEREL_API_KEY: ${{ secrets.MACKEREL_API_KEY }}
-          MACKEREL_EXPERIMENTAL_TFFRAMEWORK: ${{ matrix.framework }}
+          MACKEREL_LEGACY_SDK: ${{ matrix.implementation == 'sdk' && '1' || '0' }}
           EXTERNAL_ID: ${{ secrets.EXTERNAL_ID }}
           AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
This pull request makes a new implementation based on [terraform-plugin-framework](https://developer.hashicorp.com/terraform/plugin/framework) the default, while making the old implementation opt-in.
The legacy implementation remains available by setting the environment variable MACKEREL_LEGACY_SDK to `1` or `true`.


Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS=TestAccXXX

...
```
