### PR TITLE
fix: sdkflag

### DIFF
--- a/mackerel/provider.go
+++ b/mackerel/provider.go
@@ -79,7 +79,7 @@ func ProtoV5ProviderServer() tfprotov5.ProviderServer {
 
 func protoV5ProviderServer(provider *schema.Provider) tfprotov5.ProviderServer {
 	fwEnabled := true
-	if sdkFlag := os.Getenv("MACKEREL_LEGACY_SDK"); sdkFlag == "" {
+	if sdkFlag := os.Getenv("MACKEREL_LEGACY_SDK"); sdkFlag != "" {
 		useSDK, err := strconv.ParseBool(sdkFlag)
 		if err != nil {
 			log.Printf("[WARN] MACKEREL_LEGACY_SDK is not a valid boolean: %s", sdkFlag)


### PR DESCRIPTION
Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS=TestAccXXX

...
```
