### PR TITLE
doc: fixed the name for checking internal in mackerel_monitor's anomaly_detection.

### DIFF
--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -120,7 +120,7 @@ resource "mackerel_monitor" "anomaly_detection" {
   anomaly_detection {
     scopes              = ["myService: myRole"]
     warning_sensitivity = "insensitive"
-    maxCheckAttempts    = 3
+    max_check_attempts  = 3
   }
 }
 ```


### PR DESCRIPTION

```
Error: Unsupported argument

   on monitor_anolay_detection.tf line 9, in resource "mackerel_monitor" "my_anomaly_detection":
    9:     maxCheckAttempts     = 3

 An argument named "maxCheckAttempts" is not expected here.
```