### PR TITLE
add all valid values to channel events to documents

### DIFF
--- a/docs/resources/channel.md
+++ b/docs/resources/channel.md
@@ -62,19 +62,19 @@ The following arguments are required:
 
 * `emails` - A set of email addresses to receive notifications.
 * `user_ids` - A set of user IDs to receive notifications.
-* `events` - A set of notification events. Valid values are `alert` or `alertGroup`.
+* `events` - A set of notification events. Valid values are `alert`, `alertGroup`, `hostStatus`, `hostRegister`, `hostRetire` and `monitor`.
 
 ### slack
 
 * `url` - Incoming Webhook URL for Slack.
 * `mentions` - A map of mentions. Valid values are `ok`, `warning`, or `critical`.
 * `enabled_graph_image` - A boolean value whether to post the corresponding graph. Default `false`.
-* `events` - A set of notification events. Valid values are `alert` or `alertGroup`.
+* `events` - A set of notification events. Valid values are `alert`, `alertGroup`, `hostStatus`, `hostRegister`, `hostRetire` and `monitor`.
 
 ### webhook
 
 * `url` - URL to receive HTTP request.
-* `events` - A set of notification events. Valid values are `alert` or `alertGroup`.
+* `events` - A set of notification events. Valid values are `alert`, `alertGroup`, `hostStatus`, `hostRegister`, `hostRetire` and `monitor`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
I add missing event types for Mackerel's channels to document. The implementation is in https://github.com/mackerelio-labs/terraform-provider-mackerel/blob/0ae70e123e9e4d414bd181cca4ac29d5b375548f/internal/provider/resource_mackerel_channel.go#L146-L160

Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS=TestAccXXX

...
```
