### PR TITLE
Fix handling of optional fields in mackerel_dashbord

### DIFF
--- a/internal/mackerel/dashboard_test.go
+++ b/internal/mackerel/dashboard_test.go
@@ -79,6 +79,59 @@ func Test_Dashboard_conv(t *testing.T) {
 				UpdatedAt:   types.Int64Value(1439346145003),
 			},
 		},
+		"no range": {
+			api: mackerel.Dashboard{
+				ID:      "2c5bLca8d",
+				Title:   "role graph dashboard title",
+				Memo:    "role graph dashboard",
+				URLPath: "role-graph-dashboard",
+				Widgets: []mackerel.Widget{{
+					Type:  "graph",
+					Title: "role graph",
+					Graph: mackerel.Graph{
+						Type:         "role",
+						RoleFullName: "service:role",
+						Name:         "loadavg5",
+						IsStacked:    true,
+					},
+					Layout: mackerel.Layout{
+						X:      2,
+						Y:      12,
+						Width:  10,
+						Height: 8,
+					},
+				}},
+				CreatedAt: 1439346145003,
+				UpdatedAt: 1439346145003,
+			},
+			model: DashboardModel{
+				ID:      types.StringValue("2c5bLca8d"),
+				Title:   types.StringValue("role graph dashboard title"),
+				Memo:    types.StringValue("role graph dashboard"),
+				URLPath: types.StringValue("role-graph-dashboard"),
+				Graph: []DashboardWidgetGraph{{
+					DashboardWidget: DashboardWidget{
+						Title: types.StringValue("role graph"),
+						Layout: []DashboardLayout{{
+							X:      types.Int64Value(2),
+							Y:      types.Int64Value(12),
+							Width:  types.Int64Value(10),
+							Height: types.Int64Value(8),
+						}},
+					},
+					Role: []DashboardGraphRole{{
+						RoleFullname: types.StringValue("service:role"),
+						Name:         types.StringValue("loadavg5"),
+						IsStacked:    types.BoolValue(true),
+					}},
+				}},
+				Value:       []DashboardWidgetValue{},
+				Markdown:    []DashboardWidgetMarkdown{},
+				AlertStatus: []DashboardWidgetAlertStatus{},
+				CreatedAt:   types.Int64Value(1439346145003),
+				UpdatedAt:   types.Int64Value(1439346145003),
+			},
+		},
 	}
 
 	for name, tt := range cases {

--- a/internal/provider/resource_mackerel_dashboard.go
+++ b/internal/provider/resource_mackerel_dashboard.go
@@ -406,7 +406,9 @@ var schemaDashboardResource_graph = schema.ListNestedBlock{
 						},
 						"legend": schema.StringAttribute{
 							Description: schemaDashboardGraph_query_legendDesc,
-							Required:    true,
+							Optional:    true,
+							Computed:    true,
+							Default:     stringdefault.StaticString(""),
 						},
 					},
 				},
@@ -528,7 +530,9 @@ var schemaDashboardResource_value = schema.ListNestedBlock{
 									},
 									"legend": schema.StringAttribute{
 										Description: schemaDashboardValue_query_legendDesc,
-										Required:    true,
+										Optional:    true,
+										Computed:    true,
+										Default:     stringdefault.StaticString(""),
 									},
 								},
 							},

--- a/internal/provider/resource_mackerel_dashboard_test.go
+++ b/internal/provider/resource_mackerel_dashboard_test.go
@@ -2,9 +2,12 @@ package provider_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider"
 )
 
@@ -22,4 +25,59 @@ func Test_MackerelDashboardResource_schema(t *testing.T) {
 	if diags := resp.Schema.ValidateImplementation(ctx); diags.HasError() {
 		t.Fatalf("schema validation diagnostics: %+v", diags)
 	}
+}
+
+func TestAccMackerelDashboardGraphWithoutRange(t *testing.T) {
+	resourceName := "mackerel_dashboard.graph"
+	rand := acctest.RandString(5)
+	title := fmt.Sprintf("tf-dashboard graph %s", rand)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV5ProviderFactories: protoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Test: Create
+			{
+				Config: `
+resource "mackerel_service" "include" {
+  name = "tf-service-` + rand + `-include"
+}
+
+resource "mackerel_role" "include" {
+  service = mackerel_service.include.name
+  name    = "tf-role-` + rand + `-include"
+}
+
+resource "mackerel_dashboard" "graph" {
+  title = "` + title + `"
+  url_path = "` + rand + `"
+  graph {
+    title = "test graph role"
+    role {
+      role_fullname = "${mackerel_service.include.name}:${mackerel_role.include.name}"
+      name = "loadavg5"
+      is_stacked = true
+    }
+    layout {
+      x = 2
+      y = 12
+      width = 10
+      height = 8
+    }
+  }
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "title", title),
+					resource.TestCheckResourceAttr(resourceName, "url_path", rand),
+					resource.TestCheckResourceAttr(resourceName, "graph.#", "1"),
+				),
+			},
+			// Test: Import
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
 }


### PR DESCRIPTION
Fixes #306 

Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS='MackerelDashboard'
TF_ACC=1 go test -v ./... -run MackerelDashboard -timeout 120m
?       github.com/mackerelio-labs/terraform-provider-mackerel  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel        0.467s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/planmodifierutil        0.241s [no tests to run]
=== RUN   Test_MackerelDashboardDataSource_schema
=== PAUSE Test_MackerelDashboardDataSource_schema
=== RUN   Test_MackerelDashboardResource_schema
=== PAUSE Test_MackerelDashboardResource_schema
=== CONT  Test_MackerelDashboardDataSource_schema
=== CONT  Test_MackerelDashboardResource_schema
--- PASS: Test_MackerelDashboardDataSource_schema (0.00s)
--- PASS: Test_MackerelDashboardResource_schema (0.00s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider        1.297s
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/typeutil        0.373s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/validatorutil   0.540s [no tests to run]
=== RUN   TestAccDataSourceMackerelDashboardGraph
=== PAUSE TestAccDataSourceMackerelDashboardGraph
=== RUN   TestAccDataSourceMackerelDashboardValue
=== PAUSE TestAccDataSourceMackerelDashboardValue
=== RUN   TestAccDataSourceMackerelDashboardMarkdown
=== PAUSE TestAccDataSourceMackerelDashboardMarkdown
=== RUN   TestAccDataSourceMackerelDashboardAlertStatus
=== PAUSE TestAccDataSourceMackerelDashboardAlertStatus
=== RUN   TestAccMackerelDashboardGraph
=== PAUSE TestAccMackerelDashboardGraph
=== RUN   TestAccMackerelDashboardGraphWithoutRange
=== PAUSE TestAccMackerelDashboardGraphWithoutRange
=== RUN   TestAccMackerelDashboardValue
=== PAUSE TestAccMackerelDashboardValue
=== RUN   TestAccMackerelDashboardMarkdown
=== PAUSE TestAccMackerelDashboardMarkdown
=== RUN   TestAccMackerelDashboardAlertStatus
=== PAUSE TestAccMackerelDashboardAlertStatus
=== CONT  TestAccDataSourceMackerelDashboardGraph
=== CONT  TestAccMackerelDashboardGraphWithoutRange
=== CONT  TestAccDataSourceMackerelDashboardAlertStatus
=== CONT  TestAccDataSourceMackerelDashboardMarkdown
=== CONT  TestAccDataSourceMackerelDashboardValue
=== CONT  TestAccMackerelDashboardGraph
=== CONT  TestAccMackerelDashboardMarkdown
=== CONT  TestAccMackerelDashboardAlertStatus
=== CONT  TestAccMackerelDashboardValue
--- PASS: TestAccDataSourceMackerelDashboardMarkdown (4.54s)
--- PASS: TestAccDataSourceMackerelDashboardAlertStatus (4.88s)
--- PASS: TestAccDataSourceMackerelDashboardGraph (5.12s)
--- PASS: TestAccMackerelDashboardGraphWithoutRange (6.13s)
--- PASS: TestAccDataSourceMackerelDashboardValue (7.30s)
--- PASS: TestAccMackerelDashboardMarkdown (7.74s)
--- PASS: TestAccMackerelDashboardValue (8.35s)
--- PASS: TestAccMackerelDashboardAlertStatus (8.57s)
--- PASS: TestAccMackerelDashboardGraph (8.87s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel 10.503s
```
