### PR TITLE
fix: provider config values not merged when environment variables are unset

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -54,10 +54,10 @@ func (m *mackerelProvider) Configure(ctx context.Context, req provider.Configure
 
 	config := mackerel.NewClientConfigFromEnv()
 	// merge config
-	if config.APIKey.IsUnknown() {
+	if config.APIKey.IsNull() {
 		config.APIKey = schemaConfig.APIKey
 	}
-	if config.APIBase.IsUnknown() {
+	if config.APIBase.IsNull() {
 		config.APIBase = schemaConfig.APIBase
 	}
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -6,7 +6,9 @@ import (
 
 	fwprovider "github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider"
@@ -54,5 +56,53 @@ func TestMackerelProvider_schema(t *testing.T) {
 
 	if diags := resp.Schema.ValidateImplementation(ctx); diags.HasError() {
 		t.Fatalf("Schema validation: %+v", diags)
+	}
+}
+
+func TestMackerelProvider_Configure_WithConfigOnly(t *testing.T) {
+	// Clear environment variables
+	t.Setenv("MACKEREL_API_KEY", "")
+	t.Setenv("MACKEREL_APIKEY", "")
+
+	ctx := context.Background()
+	p := provider.New()
+
+	// Get schema
+	schemaReq := fwprovider.SchemaRequest{}
+	schemaResp := &fwprovider.SchemaResponse{}
+	p.Schema(ctx, schemaReq, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("Schema error: %v", schemaResp.Diagnostics)
+	}
+
+	// Create config with api_key set
+	configValue := tftypes.NewValue(
+		tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"api_key":  tftypes.String,
+				"api_base": tftypes.String,
+			},
+		},
+		map[string]tftypes.Value{
+			"api_key":  tftypes.NewValue(tftypes.String, "test_api_key_from_config"),
+			"api_base": tftypes.NewValue(tftypes.String, nil),
+		},
+	)
+
+	req := fwprovider.ConfigureRequest{
+		Config: tfsdk.Config{
+			Schema: schemaResp.Schema,
+			Raw:    configValue,
+		},
+	}
+	resp := &fwprovider.ConfigureResponse{}
+
+	p.Configure(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Errorf("Expected no error, but got: %v", resp.Diagnostics)
+	}
+	if resp.ResourceData == nil {
+		t.Error("Expected ResourceData to be set, but got nil")
 	}
 }


### PR DESCRIPTION
## Overview

This PR fixes the provider configuration merge logic so that Terraform configuration values are correctly used when environment variables are not set.

Fixes https://github.com/mackerelio-labs/terraform-provider-mackerel/issues/314

## Root Cause

In the `Configure` method of `internal/provider/provider.go`, only `IsUnknown()` is checked when merging environment variables and Terraform configuration:

https://github.com/mackerelio-labs/terraform-provider-mackerel/blob/main/internal/provider/provider.go#L57-L62

```go
config := mackerel.NewClientConfigFromEnv()
// merge config
if config.APIKey.IsUnknown() {  // This is always false
    config.APIKey = schemaConfig.APIKey
}
```

Regular configuration values and values retrieved from environment variables are in the state of `IsNull()` (value not set) or `IsNull() = false` (value is set), not `IsUnknown()`.

`IsUnknown()` primarily returns `true` when the value depends on computed attributes from other resources and is not yet determined during the `terraform plan` phase (e.g., referencing `random_password.result`).

Therefore, the above conditional branch is **never executed**, and the Terraform configuration value is never merged.

---

Output from acceptance testing:

<!--
This change modifies provider configuration logic (not resources or data sources),
so unit tests are sufficient. All existing unit tests pass.
-->

```
$ go test -v ./internal/provider -run TestMackerelProvider
=== RUN   TestMackerelProvider_schema
=== PAUSE TestMackerelProvider_schema
=== RUN   TestMackerelProvider_Configure_WithConfigOnly
--- PASS: TestMackerelProvider_Configure_WithConfigOnly (0.00s)
=== CONT  TestMackerelProvider_schema
--- PASS: TestMackerelProvider_schema (0.00s)
PASS
ok  	github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider	0.899s
```

All unit tests for provider and mackerel packages pass:

```
$ go test ./internal/provider ./internal/mackerel
ok  	github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider	0.574s
ok  	github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel	0.500s
```
