### PR TITLE
Update provider versions in the usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     mackerel = {
       source  = "mackerelio-labs/mackerel"
-      version = "~> 0.3.0"
+      version = "~> 0.7.0"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     mackerel = {
       source  = "mackerelio-labs/mackerel"
-      version = "~> 0.0.1"
+      version = "~> 0.7.0"
     }
   }
 }


### PR DESCRIPTION
The provider versions in the README and docs examples are too outdated.