### PR TITLE
Support in-place channel update

### DIFF
--- a/internal/mackerel/channel.go
+++ b/internal/mackerel/channel.go
@@ -82,6 +82,15 @@ func (m *ChannelModel) Read(ctx context.Context, client *Client) error {
 	return nil
 }
 
+// Updates a channel.
+func (m *ChannelModel) Update(ctx context.Context, client *Client) error {
+	channelParam := m.mackerelChannel()
+	if _, err := client.UpdateChannelContext(ctx, m.ID.ValueString(), &channelParam); err != nil {
+		return err
+	}
+	return nil
+}
+
 // Deletes a channel.
 func (m *ChannelModel) Delete(_ context.Context, client *Client) error {
 	if _, err := client.DeleteChannel(m.ID.ValueString()); err != nil {


### PR DESCRIPTION
Support updating channel in-place.

Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS=TestAccMackerelChannel                         2025-12-02 13:28
TF_ACC=1 go test -v ./... -run TestAccMackerelChannel -timeout 120m
?       github.com/mackerelio-labs/terraform-provider-mackerel  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel        0.470s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/planmodifierutil        0.252s [no tests to run]
=== RUN   TestAccMackerelChannel_Email
=== PAUSE TestAccMackerelChannel_Email
=== RUN   TestAccMackerelChannel_Slack
=== PAUSE TestAccMackerelChannel_Slack
=== RUN   TestAccMackerelChannel_Webhook
=== PAUSE TestAccMackerelChannel_Webhook
=== RUN   TestAccMackerelChannel_TypeChange
=== PAUSE TestAccMackerelChannel_TypeChange
=== CONT  TestAccMackerelChannel_Email
=== CONT  TestAccMackerelChannel_Webhook
=== CONT  TestAccMackerelChannel_TypeChange
=== CONT  TestAccMackerelChannel_Slack
--- PASS: TestAccMackerelChannel_TypeChange (1.49s)
--- PASS: TestAccMackerelChannel_Slack (1.76s)
--- PASS: TestAccMackerelChannel_Webhook (1.85s)
--- PASS: TestAccMackerelChannel_Email (1.87s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider        2.635s
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/typeutil        0.223s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/validatorutil   0.390s [no tests to run]

```
