### PR TITLE
mackerel_monitor's query.legend parameter not required

### DIFF
--- a/internal/provider/resource_mackerel_monitor.go
+++ b/internal/provider/resource_mackerel_monitor.go
@@ -444,10 +444,7 @@ func schemaMonitorResourceQueryBlock() schema.Block {
 				},
 				"legend": schema.StringAttribute{
 					Description: schemaMonitorQuery_LegendDesc,
-					Required:    true,
-					PlanModifiers: []planmodifier.String{
-						stringplanmodifier.RequiresReplace(), // force new
-					},
+					Optional:    true,
 				},
 				"operator": schemaMonitorResourceOperatorAttr(),
 				"warning":  schemaMonitorResourceWarningAttr(),

--- a/internal/provider/resource_mackerel_monitor_test.go
+++ b/internal/provider/resource_mackerel_monitor_test.go
@@ -547,7 +547,7 @@ func TestAccMackerelMonitor_Query(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "query.#", "1"),
 					resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr(resourceName, "query.0.query", "container.cpu.utilization{k8s.deployment.name=\"nginx\"}"),
-						resource.TestCheckResourceAttr(resourceName, "query.0.legend", "cpu.utilization {{k8s.node.name}}"),
+						resource.TestCheckResourceAttr(resourceName, "query.0.legend", ""),
 						resource.TestCheckResourceAttr(resourceName, "query.0.operator", ">"),
 						resource.TestCheckResourceAttr(resourceName, "query.0.warning", "70"),
 						resource.TestCheckResourceAttr(resourceName, "query.0.critical", "90"),
@@ -898,7 +898,7 @@ resource "mackerel_monitor" "foo" {
   notification_interval = 30
   query {
     query = "container.cpu.utilization{k8s.deployment.name=\"nginx\"}"
-    legend = "cpu.utilization {{k8s.node.name}}"
+    legend = ""
     operator = ">"
     warning = "70"
     critical = "90"


### PR DESCRIPTION
https://github.com/mackerelio-labs/terraform-provider-mackerel/issues/331

Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS=TestAccXXX

...
```
