### PR TITLE
Mark channel webhook URLs as sensitive

### DIFF
--- a/internal/provider/resource_mackerel_channel.go
+++ b/internal/provider/resource_mackerel_channel.go
@@ -254,6 +254,7 @@ func schemaChannelResource() (schema.Schema, []resource.ConfigValidator) {
 						"url": schema.StringAttribute{
 							Description: schemaChannelSlack_URLDesc,
 							Required:    true,
+							Sensitive:   true,
 							Validators: []validator.String{
 								validatorutil.IsURLWithHTTPorHTTPS(),
 							},
@@ -295,6 +296,7 @@ func schemaChannelResource() (schema.Schema, []resource.ConfigValidator) {
 						"url": schema.StringAttribute{
 							Description: schemaChannelWebhook_URLDesc,
 							Required:    true,
+							Sensitive:   true,
 							Validators: []validator.String{
 								validatorutil.IsURLWithHTTPorHTTPS(),
 							},


### PR DESCRIPTION
Mark the `url` attribute in `slack` and `webhook` channel blocks as `Sensitive: true` to redact webhook URLs from plan/apply output.

These URLs are webhook endpoints that allow posting arbitrary messages to the channel, so they should be treated as secrets.

Note: After upgrading the provider, the first `terraform plan` may show a one-time update-in-place diff for existing resources; `terraform apply` resolves it.

The data source (`data.mackerel_channel`) has the same issue but requires a schema structure change (`ListAttribute` → `ListNestedAttribute`), so it will be addressed in a follow-up PR.

Output from acceptance testing:

```
$ make testacc TESTS=TestAccMackerelChannel
TF_ACC=1 go test -v ./... -run TestAccMackerelChannel -timeout 120m
=== RUN   TestAccMackerelChannel_Email
=== PAUSE TestAccMackerelChannel_Email
=== RUN   TestAccMackerelChannel_Slack
=== PAUSE TestAccMackerelChannel_Slack
=== RUN   TestAccMackerelChannel_Webhook
=== PAUSE TestAccMackerelChannel_Webhook
=== RUN   TestAccMackerelChannel_TypeChange
=== PAUSE TestAccMackerelChannel_TypeChange
=== CONT  TestAccMackerelChannel_Email
=== CONT  TestAccMackerelChannel_Webhook
=== CONT  TestAccMackerelChannel_TypeChange
=== CONT  TestAccMackerelChannel_Slack
--- PASS: TestAccMackerelChannel_TypeChange (4.99s)
--- PASS: TestAccMackerelChannel_Email (5.57s)
--- PASS: TestAccMackerelChannel_Webhook (5.61s)
--- PASS: TestAccMackerelChannel_Slack (5.64s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider    6.232s
```
