### PR TITLE
Mark data source channel webhook URLs as sensitive

### DIFF
--- a/internal/provider/data_source_mackerel_channel.go
+++ b/internal/provider/data_source_mackerel_channel.go
@@ -88,30 +88,41 @@ func schemaChannelDataSource() schema.Schema {
 					},
 				},
 			},
-			"slack": schema.ListAttribute{
+			"slack": schema.ListNestedAttribute{
 				Description: schemaChannelSlackDesc,
 				Computed:    true,
-				ElementType: types.ObjectType{
-					AttrTypes: map[string]attr.Type{
-						"url": types.StringType,
-						"mentions": types.MapType{
-							ElemType: types.StringType,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"url": schema.StringAttribute{
+							Computed:  true,
+							Sensitive: true,
 						},
-						"enabled_graph_image": types.BoolType,
-						"events": types.SetType{
-							ElemType: types.StringType,
+						"mentions": schema.MapAttribute{
+							ElementType: types.StringType,
+							Computed:    true,
+						},
+						"enabled_graph_image": schema.BoolAttribute{
+							Computed: true,
+						},
+						"events": schema.SetAttribute{
+							ElementType: types.StringType,
+							Computed:    true,
 						},
 					},
 				},
 			},
-			"webhook": schema.ListAttribute{
+			"webhook": schema.ListNestedAttribute{
 				Description: schemaChannelWebhookDesc,
 				Computed:    true,
-				ElementType: types.ObjectType{
-					AttrTypes: map[string]attr.Type{
-						"url": types.StringType,
-						"events": types.SetType{
-							ElemType: types.StringType,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"url": schema.StringAttribute{
+							Computed:  true,
+							Sensitive: true,
+						},
+						"events": schema.SetAttribute{
+							ElementType: types.StringType,
+							Computed:    true,
 						},
 					},
 				},


### PR DESCRIPTION
Closes #345
Stacked on #346

Mark the `url` attribute in `slack` and `webhook` blocks of `data.mackerel_channel` as `Sensitive: true` to redact webhook URLs from plan/apply output.

To support per-attribute `Sensitive` flags, the `slack` and `webhook` blocks are changed from `schema.ListAttribute` + `types.ObjectType` to `schema.ListNestedAttribute` + `schema.NestedAttributeObject`. This is a schema-level change only — no logic changes. The `email` block is unchanged (no sensitive attributes).

**Breaking change:** If existing Terraform configs reference `data.mackerel_channel.*.slack[0].url` or `data.mackerel_channel.*.webhook[0].url` in `output` blocks, Terraform will error until a `sensitive = true` annotation (or `nonsensitive()` wrapper) is added.

Output from acceptance testing:

```
$ make testacc TESTS='TestAccDataSourceMackerelChannel'
TF_ACC=1 go test -v ./... -run TestAccDataSourceMackerelChannel -timeout 120m
?       github.com/mackerelio-labs/terraform-provider-mackerel    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/planmodifierutil    (cached) [no tests to run]
=== RUN   TestAccDataSourceMackerelChannelEmail
=== PAUSE TestAccDataSourceMackerelChannelEmail
=== RUN   TestAccDataSourceMackerelChannelSlack
=== PAUSE TestAccDataSourceMackerelChannelSlack
=== RUN   TestAccDataSourceMackerelChannelWebhook
=== PAUSE TestAccDataSourceMackerelChannelWebhook
=== RUN   TestAccDataSourceMackerelChannelNotMatchAnyChannel
=== PAUSE TestAccDataSourceMackerelChannelNotMatchAnyChannel
=== CONT  TestAccDataSourceMackerelChannelEmail
=== CONT  TestAccDataSourceMackerelChannelWebhook
=== CONT  TestAccDataSourceMackerelChannelNotMatchAnyChannel
=== CONT  TestAccDataSourceMackerelChannelSlack
--- PASS: TestAccDataSourceMackerelChannelNotMatchAnyChannel (0.89s)
--- PASS: TestAccDataSourceMackerelChannelEmail (1.73s)
--- PASS: TestAccDataSourceMackerelChannelSlack (1.77s)
--- PASS: TestAccDataSourceMackerelChannelWebhook (1.82s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider    2.204s
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/typeutil    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/validatorutil    (cached) [no tests to run]
```
