### PR TITLE
added support AWS Integration Athena

### DIFF
--- a/internal/mackerel/aws_integration.go
+++ b/internal/mackerel/aws_integration.go
@@ -68,6 +68,7 @@ type AWSIntegrationSerfvices struct {
 	Connect     AWSIntegrationServiceOpt                        `tfsdk:"connect"`
 	DocDB       AWSIntegrationServiceOpt                        `tfsdk:"docdb"`
 	CodeBuild   AWSIntegrationServiceOpt                        `tfsdk:"codebuild"`
+	Athena      AWSIntegrationServiceOpt                        `tfsdk:"athena"`
 }
 
 type AWSIntegrationService struct {
@@ -298,6 +299,7 @@ func (m *AWSIntegrationSerfvices) each(fn awsServiceEachFunc) {
 	m.Connect.each("Connect", fn)
 	m.DocDB.each("DocDB", fn)
 	m.CodeBuild.each("CodeBuild", fn)
+	m.Athena.each("Athena", fn)
 }
 
 func (s *AWSIntegrationServiceOpt) each(name string, fn awsServiceEachFunc) {

--- a/internal/mackerel/aws_integration_test.go
+++ b/internal/mackerel/aws_integration_test.go
@@ -166,7 +166,6 @@ func Test_AWSIntegration_fromAPI(t *testing.T) {
 						Role:            nil,
 						ExcludedMetrics: []string{},
 					},
-					// AWS Integration supports Athena, but the terraform provider does not.
 					"Athena": {
 						Enable:          false,
 						Role:            nil,
@@ -244,6 +243,7 @@ func Test_AWSIntegration_fromAPI(t *testing.T) {
 					Connect:    []AWSIntegrationService{},
 					DocDB:      []AWSIntegrationService{},
 					CodeBuild:  []AWSIntegrationService{},
+					Athena:     []AWSIntegrationService{},
 				},
 			},
 		},
@@ -339,6 +339,7 @@ func Test_AWSIntegration_toAPI(t *testing.T) {
 					Connect:    []AWSIntegrationService{},
 					DocDB:      []AWSIntegrationService{},
 					CodeBuild:  []AWSIntegrationService{},
+					Athena:     []AWSIntegrationService{},
 				},
 			},
 			param: mackerel.CreateAWSIntegrationParam{
@@ -397,6 +398,7 @@ func Test_AWSIntegration_toAPI(t *testing.T) {
 					"Connect":    {ExcludedMetrics: []string{}},
 					"DocDB":      {ExcludedMetrics: []string{}},
 					"CodeBuild":  {ExcludedMetrics: []string{}},
+					"Athena":     {ExcludedMetrics: []string{}},
 				},
 			},
 		},

--- a/internal/provider/resource_mackerel_aws_integration.go
+++ b/internal/provider/resource_mackerel_aws_integration.go
@@ -172,6 +172,7 @@ var awsIntegrationServices = map[string]struct {
 	"connect":     {},
 	"docdb":       {},
 	"codebuild":   {},
+	"athena":      {},
 }
 
 func schemaAWSIntegrationResource() schema.Schema {


### PR DESCRIPTION
Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS=Test_AWSIntegration_fromAPI
TF_ACC=1 go test -v ./... -run Test_AWSIntegration_fromAPI Test_AWSIntegration_toAPI -timeout 120m
?       github.com/mackerelio-labs/terraform-provider-mackerel  [no test files]
=== RUN   Test_AWSIntegration_fromAPI
=== PAUSE Test_AWSIntegration_fromAPI
=== CONT  Test_AWSIntegration_fromAPI
=== RUN   Test_AWSIntegration_fromAPI/basic
=== PAUSE Test_AWSIntegration_fromAPI/basic
=== CONT  Test_AWSIntegration_fromAPI/basic
--- PASS: Test_AWSIntegration_fromAPI (0.00s)
    --- PASS: Test_AWSIntegration_fromAPI/basic (0.00s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel        0.285s
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/planmodifierutil        0.414s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider        0.663s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/typeutil        0.356s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/validatorutil   0.730s [no tests to run]

$ make testacc TESTS=Test_AWSIntegration_toAPI
TF_ACC=1 go test -v ./... -run Test_AWSIntegration_toAPI -timeout 120m
?       github.com/mackerelio-labs/terraform-provider-mackerel  [no test files]
=== RUN   Test_AWSIntegration_toAPI
=== PAUSE Test_AWSIntegration_toAPI
=== CONT  Test_AWSIntegration_toAPI
=== RUN   Test_AWSIntegration_toAPI/basic
=== PAUSE Test_AWSIntegration_toAPI/basic
=== CONT  Test_AWSIntegration_toAPI/basic
--- PASS: Test_AWSIntegration_toAPI (0.00s)
    --- PASS: Test_AWSIntegration_toAPI/basic (0.00s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel        0.287s
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/planmodifierutil        0.426s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider        0.381s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/typeutil        0.638s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/validatorutil   0.459s [no tests to run]
```
