### PR TITLE
Fix #374: Store slack.mentions as an empty map rather then null

### DIFF
--- a/internal/mackerel/channel.go
+++ b/internal/mackerel/channel.go
@@ -131,25 +131,22 @@ func newChannel(mackerelChannel mackerel.Channel) (ChannelModel, error) {
 		}}
 		return model, nil
 	case "slack":
-		slackModel := ChannelSlackModel{
+		mentions := make(map[string]string, 3)
+		if mackerelChannel.Mentions.OK != "" {
+			mentions["ok"] = mackerelChannel.Mentions.OK
+		}
+		if mackerelChannel.Mentions.Warning != "" {
+			mentions["warning"] = mackerelChannel.Mentions.Warning
+		}
+		if mackerelChannel.Mentions.Critical != "" {
+			mentions["critical"] = mackerelChannel.Mentions.Critical
+		}
+		model.Slack = []ChannelSlackModel{{
 			URL:               types.StringValue(mackerelChannel.URL),
+			Mentions:          mentions,
 			EnabledGraphImage: types.BoolPointerValue(mackerelChannel.EnabledGraphImage),
 			Events:            *mackerelChannel.Events,
-		}
-		if mackerelChannel.Mentions != (mackerel.Mentions{}) {
-			mentions := make(map[string]string, 3)
-			if mackerelChannel.Mentions.OK != "" {
-				mentions["ok"] = mackerelChannel.Mentions.OK
-			}
-			if mackerelChannel.Mentions.Warning != "" {
-				mentions["warning"] = mackerelChannel.Mentions.Warning
-			}
-			if mackerelChannel.Mentions.Critical != "" {
-				mentions["critical"] = mackerelChannel.Mentions.Critical
-			}
-			slackModel.Mentions = mentions
-		}
-		model.Slack = []ChannelSlackModel{slackModel}
+		}}
 		return model, nil
 	case "webhook":
 		model.Webhook = []ChannelWebhookModel{{

--- a/internal/mackerel/channel_test.go
+++ b/internal/mackerel/channel_test.go
@@ -38,6 +38,7 @@ func Test_Channel_conv(t *testing.T) {
 				Name: types.StringValue("slack"),
 				Slack: []ChannelSlackModel{{
 					URL:               types.StringValue(testChannelSlackURL),
+					Mentions:          map[string]string{},
 					EnabledGraphImage: types.BoolValue(false),
 					Events:            []string{},
 				}},

--- a/internal/provider/resource_mackerel_channel_test.go
+++ b/internal/provider/resource_mackerel_channel_test.go
@@ -132,6 +132,14 @@ func TestAccMackerelChannel_Slack(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			// Test: explicit empty mentions map should not cause perpetual diff
+			{
+				Config: testAccMackerelChannelConfigSlackWithEmptyMentions(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMackerelChannelExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "slack.0.mentions.%", "0"),
+				),
+			},
 		},
 	})
 }
@@ -291,6 +299,18 @@ resource "mackerel_channel" "slack" {
   name = "%s"
   slack {
     url = "https://hooks.slack.com/services/xxx/yyy/zzz"
+  }
+}
+`, name)
+}
+
+func testAccMackerelChannelConfigSlackWithEmptyMentions(name string) string {
+	return fmt.Sprintf(`
+resource "mackerel_channel" "slack" {
+  name = "%s"
+  slack {
+    url = "https://hooks.slack.com/services/xxx/yyy/zzz"
+    mentions = {}
   }
 }
 `, name)


### PR DESCRIPTION
#374 

Output from acceptance testing:
```
$ make testacc TESTS=TestAccMackerelChannel_Slack
TF_ACC=1 go test -v ./... -run TestAccMackerelChannel_Slack -timeout 120m
?       github.com/mackerelio-labs/terraform-provider-mackerel  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel   0.473s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/planmodifierutil        0.548s [no tests to run]
=== RUN   TestAccMackerelChannel_Slack
=== PAUSE TestAccMackerelChannel_Slack
=== CONT  TestAccMackerelChannel_Slack
--- PASS: TestAccMackerelChannel_Slack (3.04s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider   3.767s
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/typeutil   0.398s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/validatorutil   0.208s [no tests to run]
```