### PR TITLE
feat: add reference lines to terraform-provider-mackerel

### DIFF
--- a/docs/data-sources/dashboard.md
+++ b/docs/data-sources/dashboard.md
@@ -46,6 +46,9 @@ data "mackerel_dashboard" "this" {
     * `query` - The PromQL-style query.
     * `legend` - The query legend.
   * `legend_list` - The list of metric names to display in the graph. Only the specified metric names will be shown. If not set, all metrics are displayed. Only valid for host graphs and service graphs.
+  * `reference_lines` - The reference line of the graph.
+    * `label` - The label of the reference line.
+    * `value` - The value of the reference line.
   * `range` - The display period for graphs. If unspecified, it will be variable and the display period can be changed from the controller displayed at the top of the dashboard.
     * `relative` - （The period from (current time + `offset` - `period`) to (current time + `offset`) is displayed. Negative values for `offset` can be used to display graphs for a specified period in the past.
       * `period` - Duration (seconds).

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -40,6 +40,10 @@ resource "mackerel_dashboard" "graph" {
         offset = 1800
       }
     }
+    reference_lines {
+      label = "SLO"
+      value = 99.9
+    }
     layout {
       x = 2
       y = 12
@@ -159,6 +163,9 @@ resource "mackerel_dashboard" "alert_status" {
   * `query` - (Required) The PromQL-style query.
   * `legend` - The query legend.
 * `legend_list` - The list of metric names to display in the graph. Only the specified metric names will be shown. If not set, all metrics are displayed. Only valid for host graphs and service graphs.
+* `reference_lines` - The reference line of the graph. Only one reference line can be specified.
+  * `label` - (Required) The label of the reference line. It must contain at least one non-whitespace character and must be 32 characters or less.
+  * `value` - (Required) The value of the reference line. It must be greater than or equal to 0.
 * `range` - The display period for graphs. If unspecified, it will be variable and thedisplay period can be changed from the controller displayed at the top of the dashboard.
   * `relative` - （The period from (current time + `offset` - `period`) to (current time + `offset`) is displayed. Negative values for `offset` can be used to display graphs for a specified period in the past.
     * `period` - (Required) Duration (seconds).

--- a/internal/mackerel/dashboard.go
+++ b/internal/mackerel/dashboard.go
@@ -37,8 +37,9 @@ type (
 
 	DashboardWidgetGraph struct {
 		DashboardWidget
-		Range      []DashboardRange `tfsdk:"range"`
-		LegendList types.List       `tfsdk:"legend_list"`
+		Range          []DashboardRange         `tfsdk:"range"`
+		LegendList     types.List               `tfsdk:"legend_list"`
+		ReferenceLines []DashboardReferenceLine `tfsdk:"reference_lines"`
 
 		Host       []DashboardGraphHost       `tfsdk:"host"`
 		Role       []DashboardGraphRole       `tfsdk:"role"`
@@ -49,6 +50,10 @@ type (
 	DashboardRange struct {
 		Relative []DashboardRangeRelative `tfsdk:"relative"`
 		Absolute []DashboardRangeAbsolute `tfsdk:"absolute"`
+	}
+	DashboardReferenceLine struct {
+		Label types.String  `tfsdk:"label"`
+		Value types.Float64 `tfsdk:"value"`
 	}
 	DashboardRangeRelative struct {
 		Period types.Int64 `tfsdk:"period"`
@@ -202,9 +207,6 @@ func newDashboard(d mackerel.Dashboard) (DashboardModel, error) {
 
 	for _, w := range d.Widgets {
 		// unsupported features
-		if len(w.ReferenceLines) != 0 {
-			return m, fmt.Errorf("referenceLines is unsupported.")
-		}
 		if len(w.FormatRules) != 0 {
 			return m, fmt.Errorf("formatFules is unsupported.")
 		}
@@ -309,6 +311,16 @@ func newDashboardWidgetGraph(w mackerel.Widget) (DashboardWidgetGraph, error) {
 		g.LegendList = types.ListNull(types.StringType)
 	}
 
+	if len(w.ReferenceLines) > 0 {
+		g.ReferenceLines = make([]DashboardReferenceLine, len(w.ReferenceLines))
+		for i, r := range w.ReferenceLines {
+			g.ReferenceLines[i] = DashboardReferenceLine{
+				Label: types.StringValue(r.Label),
+				Value: types.Float64Value(r.Value),
+			}
+		}
+	}
+
 	switch w.Range.Type {
 	case dashboardRangeTypeAbsolute:
 		g.Range = []DashboardRange{{
@@ -372,6 +384,16 @@ func (g DashboardWidgetGraph) mackerelWidget() mackerel.Widget {
 		w.LegendList = make([]string, len(elems))
 		for i, e := range elems {
 			w.LegendList[i] = e.(types.String).ValueString()
+		}
+	}
+
+	if len(g.ReferenceLines) > 0 {
+		w.ReferenceLines = make([]mackerel.ReferenceLine, len(g.ReferenceLines))
+		for i, r := range g.ReferenceLines {
+			w.ReferenceLines[i] = mackerel.ReferenceLine{
+				Label: r.Label.ValueString(),
+				Value: r.Value.ValueFloat64(),
+			}
 		}
 	}
 

--- a/internal/mackerel/dashboard_test.go
+++ b/internal/mackerel/dashboard_test.go
@@ -30,6 +30,10 @@ func Test_Dashboard_conv(t *testing.T) {
 						Name:         "loadavg5",
 						IsStacked:    true,
 					},
+					ReferenceLines: []mackerel.ReferenceLine{{
+						Label: "SLO",
+						Value: 99.9,
+					}},
 					Range: mackerel.Range{
 						Type:   "relative",
 						Period: 3600,
@@ -61,6 +65,10 @@ func Test_Dashboard_conv(t *testing.T) {
 						}},
 					},
 					LegendList: types.ListNull(types.StringType),
+					ReferenceLines: []DashboardReferenceLine{{
+						Label: types.StringValue("SLO"),
+						Value: types.Float64Value(99.9),
+					}},
 					Role: []DashboardGraphRole{{
 						RoleFullname: types.StringValue("service:role"),
 						Name:         types.StringValue("loadavg5"),

--- a/internal/provider/data_source_mackerel_dashboard.go
+++ b/internal/provider/data_source_mackerel_dashboard.go
@@ -107,6 +107,14 @@ func schemaDashboardDataSource() schema.Schema {
 						"legend_list": types.ListType{
 							ElemType: types.StringType,
 						},
+						"reference_lines": types.ListType{
+							ElemType: types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"label": types.StringType,
+									"value": types.Float64Type,
+								},
+							},
+						},
 						"range": types.ListType{
 							ElemType: types.ObjectType{
 								AttrTypes: map[string]attr.Type{

--- a/internal/provider/data_source_mackerel_dashboard_test.go
+++ b/internal/provider/data_source_mackerel_dashboard_test.go
@@ -50,6 +50,9 @@ func TestAccDataSourceMackerelDashboardGraph(t *testing.T) {
 						resource.TestCheckResourceAttr(dsName, "graph.0.role.0.name", "loadavg5"),
 						resource.TestCheckResourceAttr(dsName, "graph.0.range.0.relative.0.period", "3600"),
 						resource.TestCheckResourceAttr(dsName, "graph.0.range.0.relative.0.offset", "1800"),
+						resource.TestCheckResourceAttr(dsName, "graph.0.reference_lines.#", "1"),
+						resource.TestCheckResourceAttr(dsName, "graph.0.reference_lines.0.label", "SLO"),
+						resource.TestCheckResourceAttr(dsName, "graph.0.reference_lines.0.value", "99.9"),
 						resource.TestCheckResourceAttr(dsName, "graph.0.layout.0.x", "2"),
 						resource.TestCheckResourceAttr(dsName, "graph.0.layout.0.y", "12"),
 						resource.TestCheckResourceAttr(dsName, "graph.0.layout.0.width", "10"),
@@ -227,6 +230,10 @@ resource "mackerel_dashboard" "foo" {
         period = 3600
         offset = 1800
       }
+    }
+    reference_lines {
+      label = "SLO"
+      value = 99.9
     }
     layout {
       x = 2

--- a/internal/provider/resource_mackerel_dashboard.go
+++ b/internal/provider/resource_mackerel_dashboard.go
@@ -2,8 +2,11 @@ package provider
 
 import (
 	"context"
+	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -193,6 +196,7 @@ var schemaDashboardResource_widgetTitle = schema.StringAttribute{
 	Description: schemaDashboardWidget_titleDesc,
 	Required:    true,
 }
+
 var schemaDashboardResource_widgetLayout = schema.ListNestedBlock{
 	Description: schemaDashboardWidget_layoutDesc,
 	Validators: []validator.List{
@@ -304,6 +308,10 @@ const (
 	schemaDashboardGraph_queryDesc        = "The query graph."
 	schemaDashboardGraph_query_queryDesc  = "The PromQL-style query."
 	schemaDashboardGraph_query_legendDesc = "The query legend."
+
+	schemaDashboardGraph_referenceLinesDesc       = "The reference line of the graph. Only one reference line can be specified."
+	schemaDashboardGraph_referenceLines_labelDesc = "The label of the reference line. It must contain at least one non-whitespace character and must be 32 characters or less."
+	schemaDashboardGraph_referenceLines_valueDesc = "The value of the reference line. It must be greater than or equal to 0."
 )
 
 var schemaDashboardResource_graph = schema.ListNestedBlock{
@@ -319,6 +327,33 @@ var schemaDashboardResource_graph = schema.ListNestedBlock{
 		Blocks: map[string]schema.Block{
 			"range":  schemaDashboardResource_widgetRange,
 			"layout": schemaDashboardResource_widgetLayout,
+			"reference_lines": schema.ListNestedBlock{
+				Description: schemaDashboardGraph_referenceLinesDesc,
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"label": schema.StringAttribute{
+							Description: schemaDashboardGraph_referenceLines_labelDesc,
+							Required:    true,
+							Validators: []validator.String{
+								stringvalidator.UTF8LengthBetween(1, 32),
+								stringvalidator.RegexMatches(
+									regexp.MustCompile(`\S`),
+									"must contain at least one non-whitespace character"),
+							},
+						},
+						"value": schema.Float64Attribute{
+							Description: schemaDashboardGraph_referenceLines_valueDesc,
+							Required:    true,
+							Validators: []validator.Float64{
+								float64validator.AtLeast(0),
+							},
+						},
+					},
+				},
+			},
 
 			"host": schema.ListNestedBlock{
 				Description: schemaDashboardGraph_hostDesc,

--- a/internal/provider/resource_mackerel_dashboard_test.go
+++ b/internal/provider/resource_mackerel_dashboard_test.go
@@ -107,6 +107,9 @@ func TestAccMackerelDashboardGraph(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "graph.0.role.0.name", "loadavg5"),
 					resource.TestCheckResourceAttr(resourceName, "graph.0.range.0.relative.0.period", "3600"),
 					resource.TestCheckResourceAttr(resourceName, "graph.0.range.0.relative.0.offset", "1800"),
+					resource.TestCheckResourceAttr(resourceName, "graph.0.reference_lines.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "graph.0.reference_lines.0.label", "SLO"),
+					resource.TestCheckResourceAttr(resourceName, "graph.0.reference_lines.0.value", "99.9"),
 					resource.TestCheckResourceAttr(resourceName, "graph.0.layout.0.x", "2"),
 					resource.TestCheckResourceAttr(resourceName, "graph.0.layout.0.y", "12"),
 					resource.TestCheckResourceAttr(resourceName, "graph.0.layout.0.width", "10"),
@@ -126,6 +129,9 @@ func TestAccMackerelDashboardGraph(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "graph.0.role.0.name", "loadavg5"),
 					resource.TestCheckResourceAttr(resourceName, "graph.0.range.0.relative.0.period", "3600"),
 					resource.TestCheckResourceAttr(resourceName, "graph.0.range.0.relative.0.offset", "1800"),
+					// The reference line set on create is removed here, so this also
+					// covers deleting reference lines from an existing dashboard.
+					resource.TestCheckResourceAttr(resourceName, "graph.0.reference_lines.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "graph.0.layout.0.x", "2"),
 					resource.TestCheckResourceAttr(resourceName, "graph.0.layout.0.y", "12"),
 					resource.TestCheckResourceAttr(resourceName, "graph.0.layout.0.width", "10"),
@@ -418,6 +424,10 @@ resource "mackerel_dashboard" "graph" {
         period = 3600
         offset = 1800
       }
+    }
+    reference_lines {
+      label = "SLO"
+      value = 99.9
     }
     layout {
       x = 2


### PR DESCRIPTION
This change was implemented based on the Mackerel Dashboard API documentation.

The API defines `referenceLines` as an optional field for graph widgets, represented as an array of objects with `label` and `value`. It also specifies that an empty array can be used to remove existing reference lines, so this PR supports and tests that behavior in `mackerel_dashboard`.

  Reference: https://mackerel.io/ja/api-docs/entry/dashboards

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s

- ```

-->
```
> make testacc TESTS='TestAccMackerelDashboardGraph'
TF_ACC=1 go test -v ./... -run TestAccMackerelDashboardGraph -timeout 120m
?       github.com/mackerelio-labs/terraform-provider-mackerel  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel        0.763s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/planmodifierutil        0.428s [no tests to run]
=== RUN   TestAccMackerelDashboardGraphWithoutRange
=== PAUSE TestAccMackerelDashboardGraphWithoutRange
=== RUN   TestAccMackerelDashboardGraph
=== PAUSE TestAccMackerelDashboardGraph
=== CONT  TestAccMackerelDashboardGraphWithoutRange
=== CONT  TestAccMackerelDashboardGraph
--- PASS: TestAccMackerelDashboardGraphWithoutRange (2.93s)
--- PASS: TestAccMackerelDashboardGraph (4.72s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider        5.596s
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/typeutil        1.262s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/validatorutil   1.019s [no tests to run]
```

```
> make testacc TESTS='TestAccDataSourceMackerelDashboardGraph'
TF_ACC=1 go test -v ./... -run TestAccDataSourceMackerelDashboardGraph -timeout 120m
?       github.com/mackerelio-labs/terraform-provider-mackerel  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel        0.489s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/planmodifierutil        (cached) [no tests to run]
=== RUN   TestAccDataSourceMackerelDashboardGraph
=== PAUSE TestAccDataSourceMackerelDashboardGraph
=== CONT  TestAccDataSourceMackerelDashboardGraph
--- PASS: TestAccDataSourceMackerelDashboardGraph (3.34s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider        3.971s
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/typeutil        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/validatorutil   (cached) [no tests to run]
```