### PR TITLE
recreate manually deleted resources (monitor)

### DIFF
--- a/internal/mackerel/monitor.go
+++ b/internal/mackerel/monitor.go
@@ -2,7 +2,9 @@ package mackerel
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"slices"
 	"strconv"
 	"strings"
@@ -102,11 +104,16 @@ type MonitorAnomalyDetection struct {
 	Scopes              []string     `tfsdk:"scopes"`
 }
 
+var ErrMonitorNotFound = errors.New("monitor not found")
+
 // Reads the monitor by the id.
-// Currently non-cancelable.
-func ReadMonitor(_ context.Context, client *Client, id string) (MonitorModel, error) {
-	m, err := client.GetMonitor(id)
+func ReadMonitor(ctx context.Context, client *Client, id string) (MonitorModel, error) {
+	m, err := client.GetMonitorContext(ctx, id)
 	if err != nil {
+		var apiErr *mackerel.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+			return MonitorModel{}, fmt.Errorf("%w: %w", ErrMonitorNotFound, err)
+		}
 		return MonitorModel{}, err
 	}
 	return newMonitor(m)

--- a/internal/mackerel/monitor_test.go
+++ b/internal/mackerel/monitor_test.go
@@ -1,6 +1,9 @@
 package mackerel
 
 import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -8,6 +11,25 @@ import (
 	"github.com/mackerelio-labs/terraform-provider-mackerel/internal/typeutil"
 	"github.com/mackerelio/mackerel-client-go"
 )
+
+func Test_ReadMonitor_NotFound(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := mackerel.NewClientWithOptions("dummy-api-key", server.URL, false)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	_, err = ReadMonitor(t.Context(), client, "missing-monitor-id")
+	if !errors.Is(err, ErrMonitorNotFound) {
+		t.Errorf("expected ErrMonitorNotFound, got: %v", err)
+	}
+}
 
 func Test_Monitor_toModel(t *testing.T) {
 	t.Parallel()

--- a/internal/provider/resource_mackerel_monitor.go
+++ b/internal/provider/resource_mackerel_monitor.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
@@ -89,10 +90,16 @@ func (r *mackerelMonitorResource) Read(ctx context.Context, req resource.ReadReq
 	}
 
 	if err := data.Read(ctx, r.Client); err != nil {
+		if errors.Is(err, mackerel.ErrMonitorNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Unable to read Monitor",
 			err.Error(),
 		)
+		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/resource_mackerel_monitor.go
+++ b/internal/provider/resource_mackerel_monitor.go
@@ -156,61 +156,61 @@ const (
 
 func schemaMonitorResource() (schema.Schema, []resource.ConfigValidator) {
 	return schema.Schema{
-			Description: "This resource allows creating and management of monitors.",
-			Attributes: map[string]schema.Attribute{
-				"id": schema.StringAttribute{
-					Description: schemaMonitorIDDesc,
-					Computed:    true,
-					PlanModifiers: []planmodifier.String{
-						stringplanmodifier.UseStateForUnknown(),
-					},
-				},
-				"name": schema.StringAttribute{
-					Description: schemaMonitorNameDesc,
-					Required:    true,
-				},
-				"memo": schema.StringAttribute{
-					Description: schemaMonitorMemoDesc,
-					Optional:    true,
-					Computed:    true,
-					Default:     stringdefault.StaticString(""),
-				},
-				"is_mute": schema.BoolAttribute{
-					Description: schemaMonitorIsMuteDesc,
-					Optional:    true,
-					Computed:    true,
-					Default:     booldefault.StaticBool(false),
-				},
-				"notification_interval": schema.Int64Attribute{
-					Description: schemaMonitorNotificationIntervalDesc,
-					Optional:    true,
-					Computed:    true,
-					Default:     int64default.StaticInt64(0), // TODO(schema upgrade): handle null
-					Validators: []validator.Int64{
-						int64validator.AtLeast(0),
-					},
+		Description: "This resource allows creating and management of monitors.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: schemaMonitorIDDesc,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			Blocks: map[string]schema.Block{
-				"host_metric":       schemaMonitorResourceHostMetricBlock(),
-				"service_metric":    schemaMonitorResourceServiceMetricBlock(),
-				"expression":        schemaMonitorResourceExpressionBlock(),
-				"query":             schemaMonitorResourceQueryBlock(),
-				"connectivity":      schemaMonitorResourceConnectivityBlock(),
-				"external":          schemaMonitorResourceExternalBlock(),
-				"anomaly_detection": schemaMonitorResourceAnomalyDetectionBlock(),
+			"name": schema.StringAttribute{
+				Description: schemaMonitorNameDesc,
+				Required:    true,
 			},
-		}, []resource.ConfigValidator{
-			resourcevalidator.ExactlyOneOf(
-				path.MatchRoot("host_metric"),
-				path.MatchRoot("service_metric"),
-				path.MatchRoot("expression"),
-				path.MatchRoot("query"),
-				path.MatchRoot("connectivity"),
-				path.MatchRoot("external"),
-				path.MatchRoot("anomaly_detection"),
-			),
-		}
+			"memo": schema.StringAttribute{
+				Description: schemaMonitorMemoDesc,
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
+			},
+			"is_mute": schema.BoolAttribute{
+				Description: schemaMonitorIsMuteDesc,
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+			},
+			"notification_interval": schema.Int64Attribute{
+				Description: schemaMonitorNotificationIntervalDesc,
+				Optional:    true,
+				Computed:    true,
+				Default:     int64default.StaticInt64(0), // TODO(schema upgrade): handle null
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"host_metric":       schemaMonitorResourceHostMetricBlock(),
+			"service_metric":    schemaMonitorResourceServiceMetricBlock(),
+			"expression":        schemaMonitorResourceExpressionBlock(),
+			"query":             schemaMonitorResourceQueryBlock(),
+			"connectivity":      schemaMonitorResourceConnectivityBlock(),
+			"external":          schemaMonitorResourceExternalBlock(),
+			"anomaly_detection": schemaMonitorResourceAnomalyDetectionBlock(),
+		},
+	}, []resource.ConfigValidator{
+		resourcevalidator.ExactlyOneOf(
+			path.MatchRoot("host_metric"),
+			path.MatchRoot("service_metric"),
+			path.MatchRoot("expression"),
+			path.MatchRoot("query"),
+			path.MatchRoot("connectivity"),
+			path.MatchRoot("external"),
+			path.MatchRoot("anomaly_detection"),
+		),
+	}
 }
 
 const (

--- a/internal/provider/resource_mackerel_monitor_test.go
+++ b/internal/provider/resource_mackerel_monitor_test.go
@@ -31,6 +31,48 @@ func Test_MackerelMonitorResource_schema(t *testing.T) {
 	}
 }
 
+func TestAccMackerelMonitor_RecreateAfterManualDeletion(t *testing.T) {
+	resourceName := "mackerel_monitor.foo"
+	name := fmt.Sprintf("tf-monitor recreate %s", acctest.RandString(5))
+	config := testAccMackerelMonitorConfigHostMetric(name)
+
+	var monitorID string
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: protoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMackerelMonitorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMackerelMonitorExists(resourceName),
+					// Get monitorID from the Terraform state
+					func(s *terraform.State) error {
+						r, ok := s.RootModule().Resources[resourceName]
+						if !ok {
+							return fmt.Errorf("monitor not found from resources: %s", resourceName)
+						}
+						monitorID = r.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Simulate deletion outside Terraform
+				PreConfig: func() {
+					_, err := mackerelClient().DeleteMonitor(monitorID)
+					if err != nil {
+						t.Fatalf("failed to delete monitor: %v", err)
+					}
+				},
+				Config: config,
+				Check:  testAccCheckMackerelMonitorExists(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccMackerelMonitor_HostMetric(t *testing.T) {
 	resourceName := "mackerel_monitor.foo"
 	rand := acctest.RandString(5)


### PR DESCRIPTION
- https://github.com/mackerelio-labs/terraform-provider-mackerel/issues/380

There was a bug where terraform plan failed if a resource in the state was manually deleted.
This PR fixes the `mackerel_monitor` resource. Other resources will be updated later.

Output from acceptance testing:

<!--
PR needs to show that the changes passed the test in your local machine so you have to paste the result of `$ make testacc TESTS=TestAccXXX`.  
Environment variables are required to run tests.  
`export MACKEREL_API_KEY=<YOUR-API-KEY>`  
Additional environment variables are required for AWS Integration.  
`export AWS_ROLE_ARN`, `export EXTERNAL_ID` or  
`export AWS_ACCESS_KEY_ID`, `export AWS_SECRET_ACCESS_KEY`  
You can run specific tests by giving a function name to `TESTS`.  
ex)
```
$ make testacc TESTS=TestAccMackerelAWSIntegrationIAMRole    
TF_ACC=1 go test -v ./mackerel/... -run TestAccMackerelAWSIntegrationIAMRole -timeout 120m
=== RUN   TestAccMackerelAWSIntegrationIAMRole
=== PAUSE TestAccMackerelAWSIntegrationIAMRole
=== CONT  TestAccMackerelAWSIntegrationIAMRole
--- PASS: TestAccMackerelAWSIntegrationIAMRole (8.11s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/mackerel       8.701s
```
-->
```
$ make testacc TESTS=TestAccMackerelMonitor_RecreateAfterManualDeletion
TF_ACC=1 go test -v ./... -run TestAccMackerelMonitor_RecreateAfterManualDeletion -timeout 120m
?       github.com/mackerelio-labs/terraform-provider-mackerel  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel        0.458s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/planmodifierutil        0.816s [no tests to run]
=== RUN   TestAccMackerelMonitor_RecreateAfterManualDeletion
=== PAUSE TestAccMackerelMonitor_RecreateAfterManualDeletion
=== CONT  TestAccMackerelMonitor_RecreateAfterManualDeletion
--- PASS: TestAccMackerelMonitor_RecreateAfterManualDeletion (2.25s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider        3.695s
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/typeutil        0.796s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/validatorutil   1.104s [no tests to run]
```
