### PR TITLE
recreate manually deleted resources (all resources other than default_notification_group)

### DIFF
--- a/internal/mackerel/alert_group_setting.go
+++ b/internal/mackerel/alert_group_setting.go
@@ -17,10 +17,10 @@ type AlertGroupSettingModel struct {
 	NotificationInterval types.Int64  `tfsdk:"notification_interval"`
 }
 
-func ReadAlertGroupSetting(_ context.Context, client *Client, id string) (AlertGroupSettingModel, error) {
-	mag, err := client.GetAlertGroupSetting(id)
+func ReadAlertGroupSetting(ctx context.Context, client *Client, id string) (AlertGroupSettingModel, error) {
+	mag, err := client.GetAlertGroupSettingContext(ctx, id)
 	if err != nil {
-		return AlertGroupSettingModel{}, err
+		return AlertGroupSettingModel{}, wrapErrNotFoundIfHttp404(err)
 	}
 	return newAlertGroupSetting(*mag), nil
 }

--- a/internal/mackerel/alert_group_setting_test.go
+++ b/internal/mackerel/alert_group_setting_test.go
@@ -1,12 +1,34 @@
 package mackerel
 
 import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mackerelio/mackerel-client-go"
 )
+
+func Test_ReadAlertGroupSetting_NotFound(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := mackerel.NewClientWithOptions("dummy-api-key", server.URL, false)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	_, err = ReadAlertGroupSetting(t.Context(), client, "missing-id")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
 
 func Test_AlertGroupSetting_conv(t *testing.T) {
 	t.Parallel()

--- a/internal/mackerel/aws_integration.go
+++ b/internal/mackerel/aws_integration.go
@@ -96,14 +96,14 @@ type AWSIntegrationServiceWithRetireAutomatically struct {
 
 type AWSIntegrationServiceWithRetireAutomaticallyOpt []AWSIntegrationServiceWithRetireAutomatically // length <= 1
 
-func ReadAWSIntegration(_ context.Context, client *Client, id string) (*AWSIntegrationModel, error) {
-	return readAWSIntegration(client, id)
+func ReadAWSIntegration(ctx context.Context, client *Client, id string) (*AWSIntegrationModel, error) {
+	return readAWSIntegration(ctx, client, id)
 }
 
-func readAWSIntegration(client *Client, id string) (*AWSIntegrationModel, error) {
-	mackerelAWSIntegration, err := client.FindAWSIntegration(id)
+func readAWSIntegration(ctx context.Context, client *Client, id string) (*AWSIntegrationModel, error) {
+	mackerelAWSIntegration, err := client.FindAWSIntegrationContext(ctx, id)
 	if err != nil {
-		return nil, err
+		return nil, wrapErrNotFoundIfHttp404(err)
 	}
 	return newAWSIntegrationModel(*mackerelAWSIntegration)
 }
@@ -118,8 +118,8 @@ func (m *AWSIntegrationModel) Create(_ context.Context, client *Client) error {
 	return nil
 }
 
-func (m *AWSIntegrationModel) Read(_ context.Context, client *Client) error {
-	integration, err := readAWSIntegration(client, m.ID.ValueString())
+func (m *AWSIntegrationModel) Read(ctx context.Context, client *Client) error {
+	integration, err := readAWSIntegration(ctx, client, m.ID.ValueString())
 	if err != nil {
 		return err
 	}

--- a/internal/mackerel/aws_integration_test.go
+++ b/internal/mackerel/aws_integration_test.go
@@ -1,12 +1,34 @@
 package mackerel
 
 import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mackerelio/mackerel-client-go"
 )
+
+func Test_ReadAWSIntegration_NotFound(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := mackerel.NewClientWithOptions("dummy-api-key", server.URL, false)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	_, err = ReadAWSIntegration(t.Context(), client, "missing-id")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
 
 func Test_AWSIntegration_fromAPI(t *testing.T) {
 	t.Parallel()

--- a/internal/mackerel/channel.go
+++ b/internal/mackerel/channel.go
@@ -35,9 +35,8 @@ type (
 )
 
 // Reads a channel by the ID.
-// Currently this function is NOT cancelable.
-func ReadChannel(_ context.Context, client *Client, id string) (ChannelModel, error) {
-	channels, err := client.FindChannels()
+func ReadChannel(ctx context.Context, client *Client, id string) (ChannelModel, error) {
+	channels, err := client.FindChannelsContext(ctx)
 	if err != nil {
 		return ChannelModel{}, err
 	}
@@ -46,7 +45,7 @@ func ReadChannel(_ context.Context, client *Client, id string) (ChannelModel, er
 		return c.ID == id
 	})
 	if channelIdx < 0 {
-		return ChannelModel{}, fmt.Errorf("the ID '%s' does not match any channel in mackerel.io", id)
+		return ChannelModel{}, fmt.Errorf("%w: the ID '%s' does not match any channel in mackerel.io", ErrNotFound, id)
 	}
 
 	channel, err := newChannel(*channels[channelIdx])

--- a/internal/mackerel/channel_test.go
+++ b/internal/mackerel/channel_test.go
@@ -2,6 +2,9 @@ package mackerel
 
 import (
 	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -13,6 +16,26 @@ const (
 	testChannelSlackURL   = "https://slack.test/services/xxx/yyy/zzz"
 	testChannelWebhookURL = "https://example.test/hook"
 )
+
+func Test_ReadChannel_NotFound(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"channels":[]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := mackerel.NewClientWithOptions("dummy-api-key", server.URL, false)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	_, err = ReadChannel(t.Context(), client, "missing-id")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
 
 func Test_Channel_conv(t *testing.T) {
 	t.Parallel()

--- a/internal/mackerel/dashboard.go
+++ b/internal/mackerel/dashboard.go
@@ -123,10 +123,10 @@ type (
 	}
 )
 
-func ReadDashboard(_ context.Context, client *Client, id string) (DashboardModel, error) {
-	d, err := client.FindDashboard(id)
+func ReadDashboard(ctx context.Context, client *Client, id string) (DashboardModel, error) {
+	d, err := client.FindDashboardContext(ctx, id)
 	if err != nil {
-		return DashboardModel{}, err
+		return DashboardModel{}, wrapErrNotFoundIfHttp404(err)
 	}
 	return newDashboard(*d)
 }

--- a/internal/mackerel/dashboard_test.go
+++ b/internal/mackerel/dashboard_test.go
@@ -1,12 +1,34 @@
 package mackerel
 
 import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mackerelio/mackerel-client-go"
 )
+
+func Test_ReadDashboard_NotFound(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := mackerel.NewClientWithOptions("dummy-api-key", server.URL, false)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	_, err = ReadDashboard(t.Context(), client, "missing-id")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
 
 func Test_Dashboard_conv(t *testing.T) {
 	t.Parallel()

--- a/internal/mackerel/downtime.go
+++ b/internal/mackerel/downtime.go
@@ -49,7 +49,7 @@ func readDowntime(client downtimeFinder, id string) (*DowntimeModel, error) {
 		return d.ID == id
 	})
 	if downtimeIdx < 0 {
-		return nil, fmt.Errorf("the ID '%s' does not match any downtime in mackerel.io", id)
+		return nil, fmt.Errorf("%w: the ID '%s' does not match any downtime in mackerel.io", ErrNotFound, id)
 	}
 
 	return newDowntime(*downtimes[downtimeIdx]), nil

--- a/internal/mackerel/downtime_test.go
+++ b/internal/mackerel/downtime_test.go
@@ -1,6 +1,7 @@
 package mackerel
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -87,6 +88,9 @@ func Test_Downtime_ReadDowntime(t *testing.T) {
 				t.Errorf("unexpected error: %+v", err)
 			}
 			if err != nil {
+				if !errors.Is(err, ErrNotFound) {
+					t.Errorf("expected ErrNotFound, got: %v", err)
+				}
 				return
 			}
 			if diff := cmp.Diff(*model, tt.wants); diff != "" {

--- a/internal/mackerel/errors.go
+++ b/internal/mackerel/errors.go
@@ -1,0 +1,22 @@
+package mackerel
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+// ErrNotFound indicates that the requested resource does not exist in Mackerel.
+// Resource implementations should return this from their Read methods so that the provider can remove the resource from the state instead of failing.
+var ErrNotFound = errors.New("not found")
+
+// wrapErrNotFoundIfHttp404 wraps err with ErrNotFound if err represents a 404 response from the Mackerel API.
+func wrapErrNotFoundIfHttp404(err error) error {
+	var apiErr *mackerel.APIError
+	if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("%w: %w", ErrNotFound, err)
+	}
+	return err
+}

--- a/internal/mackerel/errors_test.go
+++ b/internal/mackerel/errors_test.go
@@ -1,0 +1,44 @@
+package mackerel
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+func Test_wrapErrNotFoundIfHttp404(t *testing.T) {
+	t.Parallel()
+
+	t.Run("404 APIError is wrapped with ErrNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		apiErr := &mackerel.APIError{StatusCode: http.StatusNotFound, Message: "not found"}
+		err := wrapErrNotFoundIfHttp404(apiErr)
+		if !errors.Is(err, ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got: %v", err)
+		}
+		if !errors.Is(err, apiErr) {
+			t.Errorf("expected the original error to be preserved, got: %v", err)
+		}
+	})
+
+	t.Run("non-404 APIError is not wrapped", func(t *testing.T) {
+		t.Parallel()
+
+		apiErr := &mackerel.APIError{StatusCode: http.StatusInternalServerError, Message: "server error"}
+		if err := wrapErrNotFoundIfHttp404(apiErr); errors.Is(err, ErrNotFound) {
+			t.Errorf("expected the error not to be ErrNotFound, got: %v", err)
+		}
+	})
+
+	t.Run("non-APIError is not wrapped", func(t *testing.T) {
+		t.Parallel()
+
+		plainErr := errors.New("some error")
+		if err := wrapErrNotFoundIfHttp404(plainErr); errors.Is(err, ErrNotFound) {
+			t.Errorf("expected the error not to be ErrNotFound, got: %v", err)
+		}
+	})
+}

--- a/internal/mackerel/monitor.go
+++ b/internal/mackerel/monitor.go
@@ -2,9 +2,7 @@ package mackerel
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"net/http"
 	"slices"
 	"strconv"
 	"strings"
@@ -104,17 +102,11 @@ type MonitorAnomalyDetection struct {
 	Scopes              []string     `tfsdk:"scopes"`
 }
 
-var ErrMonitorNotFound = errors.New("monitor not found")
-
 // Reads the monitor by the id.
 func ReadMonitor(ctx context.Context, client *Client, id string) (MonitorModel, error) {
 	m, err := client.GetMonitorContext(ctx, id)
 	if err != nil {
-		var apiErr *mackerel.APIError
-		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
-			return MonitorModel{}, fmt.Errorf("%w: %w", ErrMonitorNotFound, err)
-		}
-		return MonitorModel{}, err
+		return MonitorModel{}, wrapErrNotFoundIfHttp404(err)
 	}
 	return newMonitor(m)
 }

--- a/internal/mackerel/monitor_test.go
+++ b/internal/mackerel/monitor_test.go
@@ -26,8 +26,8 @@ func Test_ReadMonitor_NotFound(t *testing.T) {
 	}
 
 	_, err = ReadMonitor(t.Context(), client, "missing-monitor-id")
-	if !errors.Is(err, ErrMonitorNotFound) {
-		t.Errorf("expected ErrMonitorNotFound, got: %v", err)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
 	}
 }
 

--- a/internal/mackerel/notification_group.go
+++ b/internal/mackerel/notification_group.go
@@ -54,7 +54,7 @@ func readNotificationGroupInner(_ context.Context, client notificationGroupFinde
 		return ng.ID == id
 	})
 	if ngIdx < 0 {
-		return NotificationGroupModel{}, fmt.Errorf("the ID '%s' does not match any notification group in mackerel.io", id)
+		return NotificationGroupModel{}, fmt.Errorf("%w: the ID '%s' does not match any notification group in mackerel.io", ErrNotFound, id)
 	}
 
 	return newNotificationGroupModel(*ngs[ngIdx]), nil

--- a/internal/mackerel/notification_group_test.go
+++ b/internal/mackerel/notification_group_test.go
@@ -2,6 +2,7 @@ package mackerel
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -71,6 +72,10 @@ func Test_NotificationGroup_Read(t *testing.T) {
 				} else {
 					t.Errorf("unexpected error: %+v", err)
 				}
+				return
+			}
+			if err != nil && !errors.Is(err, ErrNotFound) {
+				t.Errorf("expected ErrNotFound, got: %v", err)
 				return
 			}
 

--- a/internal/mackerel/role.go
+++ b/internal/mackerel/role.go
@@ -62,7 +62,7 @@ func readRoleInner(_ context.Context, client roleFinder, serviceName, roleName s
 		return r.Name == roleName
 	})
 	if roleIdx < 0 {
-		return RoleModel{}, fmt.Errorf("the name '%s' does not match any role in mackerel.io", roleName)
+		return RoleModel{}, fmt.Errorf("%w: the name '%s' does not match any role in mackerel.io", ErrNotFound, roleName)
 	}
 
 	role := roles[roleIdx]

--- a/internal/mackerel/role_metadata.go
+++ b/internal/mackerel/role_metadata.go
@@ -43,7 +43,7 @@ type roleMetadataReader interface {
 func readRoleMetadata(client roleMetadataReader, serviceName, roleName, namespace string) (RoleMetadataModel, error) {
 	metadataResp, err := client.GetRoleMetaData(serviceName, roleName, namespace)
 	if err != nil {
-		return RoleMetadataModel{}, err
+		return RoleMetadataModel{}, wrapErrNotFoundIfHttp404(err)
 	}
 
 	metadataJSON, err := json.Marshal(metadataResp.RoleMetaData)

--- a/internal/mackerel/role_metadata_test.go
+++ b/internal/mackerel/role_metadata_test.go
@@ -1,7 +1,9 @@
 package mackerel
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -9,6 +11,19 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mackerelio/mackerel-client-go"
 )
+
+func Test_ReadRoleMetadata_NotFound(t *testing.T) {
+	t.Parallel()
+
+	inClient := roleMetadataReaderFunc(func(string, string, string) (*mackerel.RoleMetaDataResp, error) {
+		return nil, &mackerel.APIError{StatusCode: http.StatusNotFound, Message: "not found"}
+	})
+
+	_, err := readRoleMetadata(inClient, "service", "role", "namespace")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
 
 func Test_ReadRoleMetadata(t *testing.T) {
 	t.Parallel()

--- a/internal/mackerel/role_test.go
+++ b/internal/mackerel/role_test.go
@@ -2,6 +2,7 @@ package mackerel
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -61,6 +62,8 @@ func Test_Role_ReadRole(t *testing.T) {
 			if err != nil {
 				if !tt.wantErr {
 					t.Errorf("unexpected error: %+v", err)
+				} else if !errors.Is(err, ErrNotFound) {
+					t.Errorf("expected ErrNotFound, got: %v", err)
 				}
 				return
 			} else if tt.wantErr {

--- a/internal/mackerel/service.go
+++ b/internal/mackerel/service.go
@@ -61,7 +61,7 @@ func readServiceInner(client serviceFinder, name string) (ServiceModel, error) {
 		return s.Name == name
 	})
 	if serviceIdx == -1 {
-		return ServiceModel{}, fmt.Errorf("the name '%s' does not match any service in mackerel.io", name)
+		return ServiceModel{}, fmt.Errorf("%w: the name '%s' does not match any service in mackerel.io", ErrNotFound, name)
 	}
 
 	service := services[serviceIdx]

--- a/internal/mackerel/service_metadata.go
+++ b/internal/mackerel/service_metadata.go
@@ -48,7 +48,7 @@ func readServiceMetadataInner(_ context.Context, client serviceMetadataGetter, d
 
 	metadataResp, err := client.GetServiceMetaData(serviceName, namespace)
 	if err != nil {
-		return ServiceMetadataModel{}, err
+		return ServiceMetadataModel{}, wrapErrNotFoundIfHttp404(err)
 	}
 
 	data.ID = types.StringValue(serviceMetadataID(serviceName, namespace))

--- a/internal/mackerel/service_metadata_test.go
+++ b/internal/mackerel/service_metadata_test.go
@@ -2,7 +2,9 @@ package mackerel
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"slices"
 	"testing"
 
@@ -99,6 +101,22 @@ type serviceMetadataGetterFunc func(string, string) (*mackerel.ServiceMetaDataRe
 
 func (f serviceMetadataGetterFunc) GetServiceMetaData(serviceName, namespace string) (*mackerel.ServiceMetaDataResp, error) {
 	return f(serviceName, namespace)
+}
+
+func Test_ReadServiceMetadata_NotFound(t *testing.T) {
+	t.Parallel()
+
+	inClient := serviceMetadataGetterFunc(func(string, string) (*mackerel.ServiceMetaDataResp, error) {
+		return nil, &mackerel.APIError{StatusCode: http.StatusNotFound, Message: "not found"}
+	})
+
+	_, err := readServiceMetadataInner(t.Context(), inClient, ServiceMetadataModel{
+		ServiceName: types.StringValue("service0"),
+		Namespace:   types.StringValue("data0"),
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
 }
 
 func Test_ServiceMetadata_Validate(t *testing.T) {

--- a/internal/mackerel/service_test.go
+++ b/internal/mackerel/service_test.go
@@ -2,6 +2,7 @@ package mackerel
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -126,6 +127,8 @@ func Test_ReadService(t *testing.T) {
 			if err != nil {
 				if !tt.wantFail {
 					t.Errorf("unexpected error: %+v", err)
+				} else if !errors.Is(err, ErrNotFound) {
+					t.Errorf("expected ErrNotFound, got: %v", err)
 				}
 				return
 			}

--- a/internal/provider/data_source_mackerel_channel_test.go
+++ b/internal/provider/data_source_mackerel_channel_test.go
@@ -185,7 +185,7 @@ func TestAccDataSourceMackerelChannelNotMatchAnyChannel(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      `data "mackerel_channel" "foo" { id = "not-found" }`,
-				ExpectError: regexp.MustCompile(`the ID 'not-found' does not match any channel in mackerel\.io`),
+				ExpectError: regexp.MustCompile(`Unable to read a channel`),
 			},
 		},
 	})

--- a/internal/provider/data_source_mackerel_downtime_test.go
+++ b/internal/provider/data_source_mackerel_downtime_test.go
@@ -124,7 +124,7 @@ func TestAccDataSourceMackerelDowntimeNotMatchAnyDowntime(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      `data "mackerel_downtime" "foo" { id = "not-found" }`,
-				ExpectError: regexp.MustCompile(`the ID 'not-found' does not match any downtime in mackerel\.io`),
+				ExpectError: regexp.MustCompile(`Unable to read a downtime`),
 			},
 		},
 	})

--- a/internal/provider/data_source_mackerel_service_test.go
+++ b/internal/provider/data_source_mackerel_service_test.go
@@ -78,9 +78,8 @@ data "mackerel_service" "foo" {
 		"not match any service": func() []resource.TestStep {
 			name := fmt.Sprintf("tf-service-%s", acctest.RandString(5))
 			return []resource.TestStep{{
-				Config: fmt.Sprintf(`data "mackerel_service" "foo" { name = "%s" }`, name),
-				// FIXME: error message should not be tested
-				ExpectError: regexp.MustCompile(fmt.Sprintf(`the name '%s' does not match any service in mackerel\.io`, name)),
+				Config:      fmt.Sprintf(`data "mackerel_service" "foo" { name = "%s" }`, name),
+				ExpectError: regexp.MustCompile(`Unable to read Service`),
 			}}
 		},
 	}

--- a/internal/provider/resource_mackerel_alert_group_setting.go
+++ b/internal/provider/resource_mackerel_alert_group_setting.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
@@ -75,6 +76,11 @@ func (r *mackerelAlertGroupSettingResource) Read(ctx context.Context, req resour
 	}
 
 	if err := data.Read(ctx, r.Client); err != nil {
+		if errors.Is(err, mackerel.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Unable to read an alert group setting.",
 			err.Error(),

--- a/internal/provider/resource_mackerel_alert_group_setting_test.go
+++ b/internal/provider/resource_mackerel_alert_group_setting_test.go
@@ -29,6 +29,48 @@ func Test_MackerelAlertGroupSettingResource_schema(t *testing.T) {
 	}
 }
 
+func TestAccMackerelAlertGroupSetting_RecreateAfterManualDeletion(t *testing.T) {
+	resourceName := "mackerel_alert_group_setting.foo"
+	name := fmt.Sprintf("tf-alert-group-setting recreate %s", acctest.RandString(5))
+	config := testAccMackerelAlertGroupSettingConfig(name)
+
+	var settingID string
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: protoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMackerelAlertGroupSettingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMackerelAlertGroupSettingExists(resourceName),
+					// Get settingID from the Terraform state
+					func(s *terraform.State) error {
+						r, ok := s.RootModule().Resources[resourceName]
+						if !ok {
+							return fmt.Errorf("alert group setting not found from resources: %s", resourceName)
+						}
+						settingID = r.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Simulate deletion outside Terraform
+				PreConfig: func() {
+					_, err := mackerelClient().DeleteAlertGroupSetting(settingID)
+					if err != nil {
+						t.Fatalf("failed to delete alert group setting: %v", err)
+					}
+				},
+				Config: config,
+				Check:  testAccCheckMackerelAlertGroupSettingExists(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccMackerelAlertGroupSetting(t *testing.T) {
 	resourceName := "mackerel_alert_group_setting.foo"
 	rand := acctest.RandString(5)

--- a/internal/provider/resource_mackerel_aws_integration.go
+++ b/internal/provider/resource_mackerel_aws_integration.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -75,6 +76,11 @@ func (r *mackerelAWSIntegrationResource) Read(ctx context.Context, req resource.
 	}
 
 	if err := data.Read(ctx, r.Client); err != nil {
+		if errors.Is(err, mackerel.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Unable to read aws integration settings",
 			err.Error(),

--- a/internal/provider/resource_mackerel_aws_integration_test.go
+++ b/internal/provider/resource_mackerel_aws_integration_test.go
@@ -29,6 +29,58 @@ func Test_MackerelAWSIntegrationResource_schema(t *testing.T) {
 	}
 }
 
+func TestAccMackerelAWSIntegration_RecreateAfterManualDeletion(t *testing.T) {
+	resourceName := "mackerel_aws_integration.foo"
+	rand := acctest.RandString(5)
+	name := fmt.Sprintf("tf-aws-integration recreate %s", rand)
+
+	externalID := os.Getenv("EXTERNAL_ID")
+	if externalID == "" {
+		t.Skip("EXTERNAL_ID must be set for acceptance tests")
+	}
+	awsRoleArn := os.Getenv("AWS_ROLE_ARN")
+	if awsRoleArn == "" {
+		t.Skip("AWS_ROLE_ARN must be set for acceptance tests")
+	}
+	config := testAccSourceMackerelAWSIntegrationConfigIAMRole(rand, name, awsRoleArn, externalID)
+
+	var integrationID string
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: protoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMackerelAWSIntegrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMackerelAWSIntegrationExists(resourceName),
+					// Get integrationID from the Terraform state
+					func(s *terraform.State) error {
+						r, ok := s.RootModule().Resources[resourceName]
+						if !ok {
+							return fmt.Errorf("aws integration not found from resources: %s", resourceName)
+						}
+						integrationID = r.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Simulate deletion outside Terraform
+				PreConfig: func() {
+					_, err := mackerelClient().DeleteAWSIntegration(integrationID)
+					if err != nil {
+						t.Fatalf("failed to delete aws integration: %v", err)
+					}
+				},
+				Config: config,
+				Check:  testAccCheckMackerelAWSIntegrationExists(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccMackerelAWSIntegrationIAMRole(t *testing.T) {
 	resourceName := "mackerel_aws_integration.foo"
 	rand := acctest.RandString(5)

--- a/internal/provider/resource_mackerel_channel.go
+++ b/internal/provider/resource_mackerel_channel.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
@@ -85,6 +86,11 @@ func (r *mackerelChannelResource) Read(ctx context.Context, req resource.ReadReq
 	}
 
 	if err := data.Read(ctx, r.Client); err != nil {
+		if errors.Is(err, mackerel.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Unable to read a channel",
 			err.Error(),

--- a/internal/provider/resource_mackerel_channel_test.go
+++ b/internal/provider/resource_mackerel_channel_test.go
@@ -30,6 +30,48 @@ func Test_MackerelChannelResource_schema(t *testing.T) {
 	}
 }
 
+func TestAccMackerelChannel_RecreateAfterManualDeletion(t *testing.T) {
+	resourceName := "mackerel_channel.email"
+	name := fmt.Sprintf("tf-channel recreate %s", acctest.RandString(5))
+	config := testAccMackerelChannelConfigEmail(name)
+
+	var channelID string
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: protoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMackerelChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMackerelChannelExists(resourceName),
+					// Get channelID from the Terraform state
+					func(s *terraform.State) error {
+						r, ok := s.RootModule().Resources[resourceName]
+						if !ok {
+							return fmt.Errorf("channel not found from resources: %s", resourceName)
+						}
+						channelID = r.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Simulate deletion outside Terraform
+				PreConfig: func() {
+					_, err := mackerelClient().DeleteChannel(channelID)
+					if err != nil {
+						t.Fatalf("failed to delete channel: %v", err)
+					}
+				},
+				Config: config,
+				Check:  testAccCheckMackerelChannelExists(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccMackerelChannel_Email(t *testing.T) {
 	resourceName := "mackerel_channel.email"
 	rand := acctest.RandString(5)

--- a/internal/provider/resource_mackerel_dashboard.go
+++ b/internal/provider/resource_mackerel_dashboard.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
@@ -77,6 +78,11 @@ func (r *mackerelDashboardResource) Read(ctx context.Context, req resource.ReadR
 	}
 
 	if err := data.Read(ctx, r.Client); err != nil {
+		if errors.Is(err, mackerel.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Unable to read a dashboard",
 			err.Error(),

--- a/internal/provider/resource_mackerel_dashboard_test.go
+++ b/internal/provider/resource_mackerel_dashboard_test.go
@@ -28,6 +28,49 @@ func Test_MackerelDashboardResource_schema(t *testing.T) {
 	}
 }
 
+func TestAccMackerelDashboard_RecreateAfterManualDeletion(t *testing.T) {
+	resourceName := "mackerel_dashboard.graph"
+	rand := acctest.RandString(5)
+	title := fmt.Sprintf("tf-dashboard recreate %s", rand)
+	config := testAccMackerelDashboardConfigGraph(rand, title)
+
+	var dashboardID string
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: protoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMackerelDashboardDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMackerelDashboardExists(resourceName),
+					// Get dashboardID from the Terraform state
+					func(s *terraform.State) error {
+						r, ok := s.RootModule().Resources[resourceName]
+						if !ok {
+							return fmt.Errorf("dashboard not found from resources: %s", resourceName)
+						}
+						dashboardID = r.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Simulate deletion outside Terraform
+				PreConfig: func() {
+					_, err := mackerelClient().DeleteDashboard(dashboardID)
+					if err != nil {
+						t.Fatalf("failed to delete dashboard: %v", err)
+					}
+				},
+				Config: config,
+				Check:  testAccCheckMackerelDashboardExists(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccMackerelDashboardGraphWithoutRange(t *testing.T) {
 	resourceName := "mackerel_dashboard.graph"
 	rand := acctest.RandString(5)

--- a/internal/provider/resource_mackerel_downtime.go
+++ b/internal/provider/resource_mackerel_downtime.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
@@ -76,6 +77,11 @@ func (r *mackerelDowntimeResource) Read(ctx context.Context, req resource.ReadRe
 	}
 
 	if err := data.Read(ctx, r.Client); err != nil {
+		if errors.Is(err, mackerel.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Unable to read a downtime",
 			err.Error(),

--- a/internal/provider/resource_mackerel_downtime_test.go
+++ b/internal/provider/resource_mackerel_downtime_test.go
@@ -29,6 +29,48 @@ func Test_MackerelDowntimeResource_schema(t *testing.T) {
 	}
 }
 
+func TestAccMackerelDowntime_RecreateAfterManualDeletion(t *testing.T) {
+	resourceName := "mackerel_downtime.foo"
+	name := fmt.Sprintf("tf-downtime recreate %s", acctest.RandString(5))
+	config := testAccMackerelDowntimeConfig(name)
+
+	var downtimeID string
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: protoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMackerelDowntimeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMackerelDowntimeExists(resourceName),
+					// Get downtimeID from the Terraform state
+					func(s *terraform.State) error {
+						r, ok := s.RootModule().Resources[resourceName]
+						if !ok {
+							return fmt.Errorf("downtime not found from resources: %s", resourceName)
+						}
+						downtimeID = r.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Simulate deletion outside Terraform
+				PreConfig: func() {
+					_, err := mackerelClient().DeleteDowntime(downtimeID)
+					if err != nil {
+						t.Fatalf("failed to delete downtime: %v", err)
+					}
+				},
+				Config: config,
+				Check:  testAccCheckMackerelDowntimeExists(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccMackerelDowntime(t *testing.T) {
 	resourceName := "mackerel_downtime.foo"
 	rand := acctest.RandString(5)

--- a/internal/provider/resource_mackerel_monitor.go
+++ b/internal/provider/resource_mackerel_monitor.go
@@ -90,7 +90,7 @@ func (r *mackerelMonitorResource) Read(ctx context.Context, req resource.ReadReq
 	}
 
 	if err := data.Read(ctx, r.Client); err != nil {
-		if errors.Is(err, mackerel.ErrMonitorNotFound) {
+		if errors.Is(err, mackerel.ErrNotFound) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/resource_mackerel_notification_group.go
+++ b/internal/provider/resource_mackerel_notification_group.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -160,6 +161,11 @@ func (r *mackerelNotificationGroupResource) Read(ctx context.Context, req resour
 	}
 
 	if err := data.Read(ctx, r.Client); err != nil {
+		if errors.Is(err, mackerel.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Unable read Notification Group",
 			err.Error(),

--- a/internal/provider/resource_mackerel_notification_group_test.go
+++ b/internal/provider/resource_mackerel_notification_group_test.go
@@ -29,6 +29,48 @@ func Test_MackerelNotificationGroupResource_schema(t *testing.T) {
 	}
 }
 
+func TestAccMackerelNotificationGroup_RecreateAfterManualDeletion(t *testing.T) {
+	resourceName := "mackerel_notification_group.foo"
+	name := fmt.Sprintf("tf-notification-group recreate %s", acctest.RandString(5))
+	config := testAccMackerelNotificationGroupConfig(name)
+
+	var groupID string
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: protoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMackerelNotificationGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMackerelNotificationGroupExists(resourceName),
+					// Get groupID from the Terraform state
+					func(s *terraform.State) error {
+						r, ok := s.RootModule().Resources[resourceName]
+						if !ok {
+							return fmt.Errorf("notification group not found from resources: %s", resourceName)
+						}
+						groupID = r.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Simulate deletion outside Terraform
+				PreConfig: func() {
+					_, err := mackerelClient().DeleteNotificationGroup(groupID)
+					if err != nil {
+						t.Fatalf("failed to delete notification group: %v", err)
+					}
+				},
+				Config: config,
+				Check:  testAccCheckMackerelNotificationGroupExists(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccMackerelNotificationGroup(t *testing.T) {
 	resourceName := "mackerel_notification_group.foo"
 	rand := acctest.RandString(5)

--- a/internal/provider/resource_mackerel_role.go
+++ b/internal/provider/resource_mackerel_role.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -109,6 +110,11 @@ func (r *mackerelRoleResource) Read(ctx context.Context, req resource.ReadReques
 	}
 
 	if err := data.Read(ctx, r.Client); err != nil {
+		if errors.Is(err, mackerel.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Unable to read Role",
 			err.Error(),

--- a/internal/provider/resource_mackerel_role_metadata.go
+++ b/internal/provider/resource_mackerel_role_metadata.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -113,6 +114,11 @@ func (r *mackerelRoleMetadataResource) Read(ctx context.Context, req resource.Re
 	}
 
 	if err := data.Read(ctx, r.Client); err != nil {
+		if errors.Is(err, mackerel.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Unable to read Role Metadata",
 			err.Error(),

--- a/internal/provider/resource_mackerel_role_metadata_test.go
+++ b/internal/provider/resource_mackerel_role_metadata_test.go
@@ -28,6 +28,37 @@ func Test_MackerelRoleMetadataResource_schema(t *testing.T) {
 	}
 }
 
+func TestAccMackerelRoleMetadata_RecreateAfterManualDeletion(t *testing.T) {
+	resourceName := "mackerel_role_metadata.foo"
+	rand := acctest.RandString(5)
+	serviceName := fmt.Sprintf("tf-%s", rand)
+	roleName := fmt.Sprintf("tf-%s-role", rand)
+	namespace := fmt.Sprintf("tf-namespace-%s-recreate", rand)
+	config := testAccMackerelRoleMetadataConfig(serviceName, roleName, namespace)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: protoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMackerelRoleMetadataDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  testAccCheckMackerelRoleMetadataExists(resourceName),
+			},
+			{
+				// Simulate deletion outside Terraform
+				PreConfig: func() {
+					if err := mackerelClient().DeleteRoleMetaData(serviceName, roleName, namespace); err != nil {
+						t.Fatalf("failed to delete role metadata: %v", err)
+					}
+				},
+				Config: config,
+				Check:  testAccCheckMackerelRoleMetadataExists(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccMackerelRoleMetadata(t *testing.T) {
 	resourceName := "mackerel_role_metadata.foo"
 	rand := acctest.RandString(5)

--- a/internal/provider/resource_mackerel_role_test.go
+++ b/internal/provider/resource_mackerel_role_test.go
@@ -30,6 +30,37 @@ func Test_MackerelRoleResource_schema(t *testing.T) {
 	}
 }
 
+func TestAccMackerelRole_RecreateAfterManualDeletion(t *testing.T) {
+	resourceName := "mackerel_role.bar"
+	rand := acctest.RandString(5)
+	serviceName := fmt.Sprintf("tf-service-%s", rand)
+	name := fmt.Sprintf("tf-role-%s-recreate", rand)
+	config := testAccMackerelRoleConfig(serviceName, name)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: protoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMackerelRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  testAccCheckMackerelRoleExists(resourceName),
+			},
+			{
+				// Simulate deletion outside Terraform
+				PreConfig: func() {
+					_, err := mackerelClient().DeleteRole(serviceName, name)
+					if err != nil {
+						t.Fatalf("failed to delete role: %v", err)
+					}
+				},
+				Config: config,
+				Check:  testAccCheckMackerelRoleExists(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccMackerelRole(t *testing.T) {
 	resourceName := "mackerel_role.bar"
 	rand := acctest.RandString(5)

--- a/internal/provider/resource_mackerel_service.go
+++ b/internal/provider/resource_mackerel_service.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -113,6 +114,11 @@ func (r *mackerelServiceResource) Read(ctx context.Context, req resource.ReadReq
 	}
 
 	if err := data.Read(ctx, r.Client); err != nil {
+		if errors.Is(err, mackerel.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Unable to read Service",
 			err.Error(),

--- a/internal/provider/resource_mackerel_service_metadata.go
+++ b/internal/provider/resource_mackerel_service_metadata.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -116,6 +117,11 @@ func (r *mackerelServiceMetadataResource) Read(ctx context.Context, req resource
 
 	remoteData, err := mackerel.ReadServiceMetadata(ctx, r.Client, data)
 	if err != nil {
+		if errors.Is(err, mackerel.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Unable to read Service Metadata: %s", data.ID.ValueString()),
 			err.Error(),

--- a/internal/provider/resource_mackerel_service_metadata_test.go
+++ b/internal/provider/resource_mackerel_service_metadata_test.go
@@ -30,6 +30,36 @@ func Test_MackerelServiceMetadataResource_schema(t *testing.T) {
 	}
 }
 
+func TestAccMackerelServiceMetadata_RecreateAfterManualDeletion(t *testing.T) {
+	resourceName := "mackerel_service_metadata.foo"
+	rand := acctest.RandString(5)
+	serviceName := fmt.Sprintf("tf-%s", rand)
+	namespace := fmt.Sprintf("tf-namespace-%s-recreate", rand)
+	config := testAccMackerelServiceMetadataConfig(serviceName, namespace)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: protoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMackerelServiceMetadataDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  testAccCheckMackerelServiceMetadataExists(resourceName),
+			},
+			{
+				// Simulate deletion outside Terraform
+				PreConfig: func() {
+					if err := mackerelClient().DeleteServiceMetaData(serviceName, namespace); err != nil {
+						t.Fatalf("failed to delete service metadata: %v", err)
+					}
+				},
+				Config: config,
+				Check:  testAccCheckMackerelServiceMetadataExists(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccMackerelServiceMetadata(t *testing.T) {
 	resourceName := "mackerel_service_metadata.foo"
 	rand := acctest.RandString(5)

--- a/internal/provider/resource_mackerel_service_test.go
+++ b/internal/provider/resource_mackerel_service_test.go
@@ -32,6 +32,39 @@ func TestMackerelServiceResourceSchema(t *testing.T) {
 	}
 }
 
+func TestAccMackerelService_RecreateAfterManualDeletion(t *testing.T) {
+	resourceName := "mackerel_service.foo"
+	name := fmt.Sprintf("tf-service-recreate-%s", acctest.RandString(5))
+	config := fmt.Sprintf(`
+resource "mackerel_service" "foo" {
+  name = "%s"
+}
+`, name)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: protoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMackerelServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  testAccCheckMackerelServiceExists(resourceName),
+			},
+			{
+				// Simulate deletion outside Terraform
+				PreConfig: func() {
+					_, err := mackerelClient().DeleteService(name)
+					if err != nil {
+						t.Fatalf("failed to delete service: %v", err)
+					}
+				},
+				Config: config,
+				Check:  testAccCheckMackerelServiceExists(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccMackerelService(t *testing.T) {
 	t.Parallel()
 	resourceName := "mackerel_service.foo"


### PR DESCRIPTION
issue: #380
This PR follows #382.   

Output from acceptance testing:


```
$ export MACKEREL_API_KEY=
$ export EXTERNAL_ID=
$ export AWS_ROLE_ARN=
$ make testacc TESTS=RecreateAfterManualDeletion
TF_ACC=1 go test -v ./... -run RecreateAfterManualDeletion -timeout 120m
?       github.com/mackerelio-labs/terraform-provider-mackerel  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/mackerel        0.773s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/planmodifierutil        0.777s [no tests to run]
=== RUN   TestAccMackerelAlertGroupSetting_RecreateAfterManualDeletion
=== PAUSE TestAccMackerelAlertGroupSetting_RecreateAfterManualDeletion
=== RUN   TestAccMackerelAWSIntegration_RecreateAfterManualDeletion
=== PAUSE TestAccMackerelAWSIntegration_RecreateAfterManualDeletion
=== RUN   TestAccMackerelChannel_RecreateAfterManualDeletion
=== PAUSE TestAccMackerelChannel_RecreateAfterManualDeletion
=== RUN   TestAccMackerelDashboard_RecreateAfterManualDeletion
=== PAUSE TestAccMackerelDashboard_RecreateAfterManualDeletion
=== RUN   TestAccMackerelDowntime_RecreateAfterManualDeletion
=== PAUSE TestAccMackerelDowntime_RecreateAfterManualDeletion
=== RUN   TestAccMackerelMonitor_RecreateAfterManualDeletion
=== PAUSE TestAccMackerelMonitor_RecreateAfterManualDeletion
=== RUN   TestAccMackerelNotificationGroup_RecreateAfterManualDeletion
=== PAUSE TestAccMackerelNotificationGroup_RecreateAfterManualDeletion
=== RUN   TestAccMackerelRoleMetadata_RecreateAfterManualDeletion
=== PAUSE TestAccMackerelRoleMetadata_RecreateAfterManualDeletion
=== RUN   TestAccMackerelRole_RecreateAfterManualDeletion
=== PAUSE TestAccMackerelRole_RecreateAfterManualDeletion
=== RUN   TestAccMackerelServiceMetadata_RecreateAfterManualDeletion
=== PAUSE TestAccMackerelServiceMetadata_RecreateAfterManualDeletion
=== RUN   TestAccMackerelService_RecreateAfterManualDeletion
=== PAUSE TestAccMackerelService_RecreateAfterManualDeletion
=== CONT  TestAccMackerelAlertGroupSetting_RecreateAfterManualDeletion
=== CONT  TestAccMackerelNotificationGroup_RecreateAfterManualDeletion
=== CONT  TestAccMackerelDashboard_RecreateAfterManualDeletion
=== CONT  TestAccMackerelChannel_RecreateAfterManualDeletion
=== CONT  TestAccMackerelMonitor_RecreateAfterManualDeletion
=== CONT  TestAccMackerelServiceMetadata_RecreateAfterManualDeletion
=== CONT  TestAccMackerelDowntime_RecreateAfterManualDeletion
=== CONT  TestAccMackerelRole_RecreateAfterManualDeletion
=== CONT  TestAccMackerelRoleMetadata_RecreateAfterManualDeletion
=== CONT  TestAccMackerelAWSIntegration_RecreateAfterManualDeletion
=== CONT  TestAccMackerelService_RecreateAfterManualDeletion
--- PASS: TestAccMackerelAlertGroupSetting_RecreateAfterManualDeletion (3.27s)
--- PASS: TestAccMackerelDowntime_RecreateAfterManualDeletion (3.79s)
--- PASS: TestAccMackerelServiceMetadata_RecreateAfterManualDeletion (5.12s)
--- PASS: TestAccMackerelService_RecreateAfterManualDeletion (5.35s)
--- PASS: TestAccMackerelRoleMetadata_RecreateAfterManualDeletion (5.64s)
--- PASS: TestAccMackerelChannel_RecreateAfterManualDeletion (5.73s)
--- PASS: TestAccMackerelNotificationGroup_RecreateAfterManualDeletion (5.75s)
--- PASS: TestAccMackerelRole_RecreateAfterManualDeletion (6.93s)
--- PASS: TestAccMackerelAWSIntegration_RecreateAfterManualDeletion (7.07s)
--- PASS: TestAccMackerelMonitor_RecreateAfterManualDeletion (7.63s)
--- PASS: TestAccMackerelDashboard_RecreateAfterManualDeletion (7.66s)
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/provider        8.649s
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/typeutil        1.293s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/mackerelio-labs/terraform-provider-mackerel/internal/validatorutil   1.622s [no tests to run]
```
